### PR TITLE
Improve recover from Elasticsearch cluster fails

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -20,7 +20,12 @@ STACK_STAC_BUCKET_PRUNE="0"
 # used to recover from ES cluster failures (see #78)
 STACK_BACKUP_QUEUE_RETENTION_DAYS=3
 
-##### Parameters switched between dev and prod deployments
+# ES cluster parameters
+STACK_ES_INSTANCE_TYPE="t2.small.elasticsearch"
+STACK_ES_VOLUME_SIZE=15
+STACK_ES_DATA_NODES=1
+
+##### Parameters typically switched between dev and prod deployments
 
 #### Development
 # STACK_STAGE="dev"

--- a/.env_example
+++ b/.env_example
@@ -15,6 +15,10 @@ STACK_STAC_BUCKET_PUBLIC_READ="1"
 # THE STAC BUCKET WHEN EITHER CATALOG AND/OR COLLECTION
 # IS UPDATED.
 STACK_STAC_BUCKET_PRUNE="0"
+# Retention period, in days, for the queue that hold
+# the history of the ingested stac items, this may be
+# used to recover from ES cluster failures (see #78)
+STACK_BACKUP_QUEUE_RETENTION_DAYS=3
 
 ##### Parameters switched between dev and prod deployments
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ $ pre-commit install
 
 Requires localstack up to execute tests:
 
+Check before if `/tmp/localstack/es_backup` directory exists, this is required to start the ES service.
+
 ```bash
 $ cd test && docker-compose up # Starts localstack
 $ pytest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cbers-2-stac
 
-![CI](https://github.com/fredliporace/cbers-2-stac/actions/workflows/ci.yml/badge.svg?branch=dev)
+![CI](https://github.com/fredliporace/cbers-2-stac/actions/workflows/ci.yml/badge.svg?branch=master)
 
 Create and keep up-to-date a [STAC](https://github.com/radiantearth/stac-spec) static catalog and an API for [CBERS-4/4A images on AWS](https://registry.opendata.aws/cbers/).
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ A tool is provided to move messages from SQS queues, this may be used to re-queu
 ## Install
 
 ```bash
-$ git clone git@github.com:AMS-Kepler/cbers-2-stac.git
+$ git clone git@github.com:fredliporace/cbers-2-stac.git
 $ cd cbers-2-stac
 $ pip install -e .[dev,test]
 $ ./pip-on-lambdas.sh

--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ A tool is provided to move messages from SQS queues, this may be used to re-queu
 ./utils/redrive_sqs_queue.py --src-url=https://... --dst-url=https://... --messages-no=100
 ```
 
+## Recovering from ElasticSearch (ES) cluster failures
+
+### Restore from ES snapshot
+
+TODO
+
+### Reingest items from backup queue
+
+TODO
+
 # Development
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ Deploy the stack, replacing ```cbers2stac-dev``` with your configured stack name
 $ cdk deploy cbers2stac-dev
 ```
 
-If ```STACK_ENABLE_API``` is set in the configuration you should now create the Elasticsearch index. This needs to be executed only once, right after the first deploy that enables the API. The index is created by the lambda ```create_elastic_index_lambda```, which may be executed from the AWS console or awscli. The function requires no parameters.
-
 The e-mail configured in ```STACK_OPERATOR_EMAIL``` receives execution alarms and while the first deploy is made it should receive a message requesting confirmation for the alarm topic subscription. Accept the request to receive the alarms.
 
 The stack output shows the SNS topic for new scenes and the API endpoint, if configured:
@@ -79,6 +77,12 @@ cbers2stac-prod.stacapiEndpointBED73CCA = https://....
 cbers2stac-prod.stacitemtopicoutput = arn:aws:sns:us-east-1:...:...
 
 ```
+
+### Creating the Elasticsearch index
+
+If ```STACK_ENABLE_API``` is set in the configuration you should now create the Elasticsearch index. This needs to be executed only once, right after the first deploy that enables the API. The index is created by the lambda ```create_elastic_index_lambda```, which may be executed from the AWS console or awscli. The function requires no parameters.
+
+It is recommended to change the cluster configuration to disable the automatic creation of indices. AFAIK this can't be done through CDK options, you need to directly access the domain configuration endpoint, see [example](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#index-creation).
 
 ## Reconciliation
 
@@ -101,7 +105,7 @@ To index all CBERS-4A MUX scenes:
 To index all CBERS-4A MUX scenes with path 120:
 ```json
 {
-  "prefix": "CBERS4A/MUX/120"
+  "prefix": "CBERS4A/MUX/120/"
 }
 ```
 

--- a/cbers2stac/reindex_stac_items/code.py
+++ b/cbers2stac/reindex_stac_items/code.py
@@ -1,0 +1,180 @@
+"""Reindex STAC items from bucket to ES."""
+
+import json
+import logging
+import os
+
+from cbers2stac.layers.common.utils import get_client, get_resource
+
+# Get rid of "Found credentials in environment variables" messages
+logging.getLogger("botocore.credentials").disabled = True
+LOGGER = logging.getLogger()
+LOGGER.setLevel(logging.INFO)
+
+
+def send_stac_items_to_queue(bucket: str, queue: str, prefix: str) -> None:
+    """send_stac_items_to_queue.
+
+    Args:
+      filter_params are passed directly to list_objects_v2 paginator.
+    """
+    sqs_queue = get_resource("sqs").Queue(queue)
+    s3_client = get_client("s3")
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for result in paginator.paginate(
+        Bucket=bucket, PaginationConfig={"PageSize": 1000}, Prefix=prefix
+    ):
+        assert result["KeyCount"] <= 1000
+        entries = [
+            {
+                "Id": str(index),
+                "MessageBody": json.dumps(
+                    {
+                        "Message": json.dumps(
+                            json.loads(
+                                s3_client.get_object(Bucket=bucket, Key=obj["Key"])[
+                                    "Body"
+                                ]
+                                .read()
+                                .decode("utf-8")
+                            )
+                        )
+                    }
+                ),
+            }
+            for index, obj in enumerate(result["Contents"])
+            if obj["Key"].split("/")[-1] not in ["catalog.json", "collection.json"]
+        ]
+        # Send items to queue at max 10 at a time
+        chunk_size = 10
+        chunked_entries = [
+            entries[i * chunk_size : (i + 1) * chunk_size]
+            for i in range((len(entries) + chunk_size - 1) // chunk_size)
+        ]
+        for chunk in chunked_entries:
+            response = sqs_queue.send_messages(Entries=chunk)
+            assert len(response["Successful"]) == len(chunk)
+
+
+def populate_queue_with_subdirs(bucket: str, prefix: str, queue: str) -> None:
+    """
+    Populate queue with messages containing S3 keys from
+    'prefix', grouped by the first occurrence of '/' after
+    'prefix'. If is required that the prefix ends with '/', which
+    means that all the subdirs will be scanned.
+
+    Input:
+      bucket(string): STAC bucket
+      prefix(string): ditto.
+      queue(string): queue url
+    """
+
+    # No reason to run the function without scanning subdirs
+    assert prefix[-1] == "/"
+
+    dirs = get_client("s3").list_objects_v2(
+        Bucket=bucket, Prefix=prefix, Delimiter="/",
+    )
+
+    # Paging is not supported here
+    assert not dirs["IsTruncated"]
+    for dir_key in dirs["CommonPrefixes"]:
+        LOGGER.info(dir_key["Prefix"])
+        get_client("sqs").send_message(QueueUrl=queue, MessageBody=dir_key["Prefix"])
+
+
+# def populate_queue_with_stac_items(bucket: str, prefix: str, suffix:str , queue: str) -> None:
+#     """
+#     Populate queue with STAC items to be indexed. The items are obtained
+#     from bucket/prefix/*/suffix
+#     """
+#     suffix = r".*" + suffix
+#     files = get_client("s3").list_objects_v2(
+#         Bucket=bucket, Prefix=prefix, RequestPayer="requester"
+#     )
+
+#     while True:
+#         for file in files["Contents"]:
+#             if re.search(suffix, file["Key"]):
+#                 # print(file['Key'])
+#                 message = dict()
+#                 message["Message"] = json.dumps(
+#                     {
+#                         "Records": [
+#                             {"s3": {"object": {"key": file["Key"], "reconcile": 1}}}
+#                         ]
+#                     }
+#                 )
+#                 get_client("sqs").send_message(
+#                     QueueUrl=queue, MessageBody=json.dumps(message)
+#                 )
+#         if not files["IsTruncated"]:
+#             break
+#         files = get_client("s3").list_objects_v2(
+#             Bucket=bucket,
+#             Prefix=prefix,
+#             ContinuationToken=files["NextContinuationToken"],
+#             RequestPayer="requester",
+#         )
+
+
+# def handler(event, context):  # pylint: disable=unused-argument
+#     """Lambda entry point
+#     Event keys:
+#       filter_params: **kwargs to list_objects_v2, typically {"Prefix":"CBERS4/AWFI/"}
+#     """
+
+#     send_stac_items_to_queue(
+#         bucket=os.environ["CBERS_STAC_BUCKET"],
+#         queue=os.environ["insert_into_elasticsearch_queue_url"],
+#         filter_params=event["filter_params"],
+#     )
+
+
+def consume_stac_reconcile_queue_handler(
+    event, context
+):  # pylint: disable=unused-argument
+    """Lambda entry point.
+    Event keys:
+      prefix(string): Common prefix of STAC items to be sent to queue
+      queue(string): URL of the queue, optional. If set a single message is read
+    """
+
+    if "queue" in event:
+        # Consume payload data from job queue, one job only
+        response = get_client("sqs").receive_message(QueueUrl=event["queue"])
+        receipt_handle = response["Messages"][0]["ReceiptHandle"]
+        send_stac_items_to_queue(
+            bucket=os.environ["CBERS_STAC_BUCKET"],
+            prefix=response["Messages"][0]["Body"],
+            queue=os.environ["insert_into_elasticsearch_queue_url"],
+        )
+        # r_params.append(json.loads(response['Messages'][0]['Body']))
+        # print(json.dumps(response, indent=2))
+        get_client("sqs").delete_message(
+            QueueUrl=event["queue"], ReceiptHandle=receipt_handle
+        )
+
+    else:
+        # Lambda called from SQS trigger
+        for record in event["Records"]:
+            send_stac_items_to_queue(
+                bucket=os.environ["CBERS_STAC_BUCKET"],
+                prefix=record["body"],
+                queue=os.environ["insert_into_elasticsearch_queue_url"],
+            )
+
+
+def populate_stac_reconcile_queue_handler(
+    event, context
+):  # pylint: disable=unused-argument
+    """Lambda entry point
+    Event keys:
+      prefix(string): Common prefix of S3 keys to be sent to queue
+    """
+
+    return populate_queue_with_subdirs(
+        bucket=os.environ["CBERS_STAC_BUCKET"],
+        prefix=event["prefix"],
+        queue=os.environ["stac_reconcile_queue_url"],
+    )

--- a/stack/app.py
+++ b/stack/app.py
@@ -571,9 +571,12 @@ class CBERS2STACStack(core.Stack):
             id="cbers2stac",
             # This is the version currently used by localstack
             version=elasticsearch.ElasticsearchVersion.V7_7,
-            ebs=elasticsearch.EbsOptions(enabled=True, volume_size=15),
+            ebs=elasticsearch.EbsOptions(
+                enabled=True, volume_size=settings.es_volume_size
+            ),
             capacity=elasticsearch.CapacityConfig(
-                data_node_instance_type="t2.small.elasticsearch", data_nodes=1,
+                data_node_instance_type=settings.es_instance_type,
+                data_nodes=settings.es_data_nodes,
             ),
             access_policies=[
                 iam.PolicyStatement(

--- a/stack/app.py
+++ b/stack/app.py
@@ -531,11 +531,13 @@ class CBERS2STACStack(core.Stack):
                 runtime=aws_lambda.Runtime.PYTHON_3_7,
                 environment=self.lambdas_env_,
                 layers=[self.layers_["common_layer"]],
-                timeout=core.Duration.seconds(600),
+                timeout=core.Duration.seconds(900),
                 description="Reindex STAC items from a prefix",
             )
+            # Batch size changed from 5 to 2 to reduce the lambda work and increase
+            # the chances to make it fit within the 900s limit.
             self.lambdas_["consume_stac_reconcile_queue_lambda"].add_event_source(
-                SqsEventSource(queue=self.queues_["stac_reconcile_queue"], batch_size=5)
+                SqsEventSource(queue=self.queues_["stac_reconcile_queue"], batch_size=2)
             )
 
             self.create_lambda(

--- a/stack/app.py
+++ b/stack/app.py
@@ -551,7 +551,7 @@ class CBERS2STACStack(core.Stack):
             id="cbers2stac",
             # This is the version currently used by localstack
             version=elasticsearch.ElasticsearchVersion.V7_7,
-            ebs=elasticsearch.EbsOptions(enabled=True, volume_size=20),
+            ebs=elasticsearch.EbsOptions(enabled=True, volume_size=15),
             capacity=elasticsearch.CapacityConfig(
                 data_node_instance_type="t2.small.elasticsearch", data_nodes=1,
             ),

--- a/stack/config.py
+++ b/stack/config.py
@@ -21,6 +21,10 @@ class StackSettings(pydantic.BaseSettings):  # pylint: disable=too-few-public-me
     stac_bucket_public_read: Optional[bool] = False
     stac_bucket_prune: bool = False
 
+    es_instance_type: str
+    es_volume_size: int
+    es_data_nodes: int
+
     enable_api: Optional[bool] = False
 
     additional_env: Dict[str, str] = {}

--- a/stack/config.py
+++ b/stack/config.py
@@ -14,6 +14,8 @@ class StackSettings(pydantic.BaseSettings):  # pylint: disable=too-few-public-me
     operator_email: str
     cost_center: Optional[str]
 
+    backup_queue_retention_days: Optional[int] = 1
+
     stac_bucket_name: str
     stac_bucket_enable_cors: Optional[bool] = False
     stac_bucket_public_read: Optional[bool] = False

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   localstack:
     container_name: cbers2stac-localstack_main
     #image: localstack/localstack
-    image: localstack/localstack-full
+    image: localstack/localstack-full:0.12.9.1
     network_mode: bridge
     #networks:
     #  - internal

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/027/CBERS_4_AWFI_20210819_001_027_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/027/CBERS_4_AWFI_20210819_001_027_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20210819_001_027_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            118.745593,
+            62.368498
+          ],
+          [
+            134.617166,
+            59.905355
+          ],
+          [
+            142.060779,
+            65.927818
+          ],
+          [
+            122.584184,
+            69.02379
+          ],
+          [
+            118.745593,
+            62.368498
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    120.347875,
+    59.039532,
+    143.267128,
+    69.348688
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-08-19T03:00:43Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 175.975,
+    "view:sun_elevation": 37.0215,
+    "view:off_nadir": 0.00586199,
+    "proj:epsg": 32653,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 1,
+    "cbers:row": 27
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/001/027/CBERS_4_AWFI_20210819_001_027_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/001/027/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/001/027/CBERS_4_AWFI_20210819_001_027_L2/CBERS_4_AWFI_20210819_001_027.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/027/CBERS_4_AWFI_20210819_001_027_L2/CBERS_4_AWFI_20210819_001_027_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/027/CBERS_4_AWFI_20210819_001_027_L2/CBERS_4_AWFI_20210819_001_027_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/027/CBERS_4_AWFI_20210819_001_027_L2/CBERS_4_AWFI_20210819_001_027_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/027/CBERS_4_AWFI_20210819_001_027_L2/CBERS_4_AWFI_20210819_001_027_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/027/CBERS_4_AWFI_20210819_001_027_L2/CBERS_4_AWFI_20210819_001_027_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/027/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/027/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 001/027",
+  "description": "CBERS4 AWFI camera path 001 row 027 catalog",
+  "title": "CBERS4 AWFI 001/027",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/001/027/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20210819_001_027_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/033/CBERS_4_AWFI_20210819_001_033_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/033/CBERS_4_AWFI_20210819_001_033_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20210819_001_033_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            116.546494,
+            57.077437
+          ],
+          [
+            130.396034,
+            54.946307
+          ],
+          [
+            135.952148,
+            61.203221
+          ],
+          [
+            119.431468,
+            63.775958
+          ],
+          [
+            116.546494,
+            57.077437
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    117.372347,
+    54.355149,
+    136.69433,
+    63.964304
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-08-19T03:02:14Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 170.075,
+    "view:sun_elevation": 42.0166,
+    "view:off_nadir": 0.00586199,
+    "proj:epsg": 32652,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 1,
+    "cbers:row": 33
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/001/033/CBERS_4_AWFI_20210819_001_033_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/001/033/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/001/033/CBERS_4_AWFI_20210819_001_033_L2/CBERS_4_AWFI_20210819_001_033.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/033/CBERS_4_AWFI_20210819_001_033_L2/CBERS_4_AWFI_20210819_001_033_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/033/CBERS_4_AWFI_20210819_001_033_L2/CBERS_4_AWFI_20210819_001_033_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/033/CBERS_4_AWFI_20210819_001_033_L2/CBERS_4_AWFI_20210819_001_033_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/033/CBERS_4_AWFI_20210819_001_033_L2/CBERS_4_AWFI_20210819_001_033_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/033/CBERS_4_AWFI_20210819_001_033_L2/CBERS_4_AWFI_20210819_001_033_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/033/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/033/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 001/033",
+  "description": "CBERS4 AWFI camera path 001 row 033 catalog",
+  "title": "CBERS4 AWFI 001/033",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/001/033/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20210819_001_033_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/039/CBERS_4_AWFI_20210819_001_039_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/039/CBERS_4_AWFI_20210819_001_039_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20210819_001_039_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            114.74627,
+            51.765674
+          ],
+          [
+            127.075994,
+            49.876232
+          ],
+          [
+            131.418193,
+            56.281983
+          ],
+          [
+            117.085618,
+            58.491262
+          ],
+          [
+            114.74627,
+            51.765674
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    115.097931,
+    49.639853,
+    131.958043,
+    58.390829
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-08-19T03:03:44Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 164.785,
+    "view:sun_elevation": 46.8329,
+    "view:off_nadir": 0.00586199,
+    "proj:epsg": 32651,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 1,
+    "cbers:row": 39
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/001/039/CBERS_4_AWFI_20210819_001_039_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/001/039/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/001/039/CBERS_4_AWFI_20210819_001_039_L2/CBERS_4_AWFI_20210819_001_039.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/039/CBERS_4_AWFI_20210819_001_039_L2/CBERS_4_AWFI_20210819_001_039_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/039/CBERS_4_AWFI_20210819_001_039_L2/CBERS_4_AWFI_20210819_001_039_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/039/CBERS_4_AWFI_20210819_001_039_L2/CBERS_4_AWFI_20210819_001_039_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/039/CBERS_4_AWFI_20210819_001_039_L2/CBERS_4_AWFI_20210819_001_039_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/039/CBERS_4_AWFI_20210819_001_039_L2/CBERS_4_AWFI_20210819_001_039_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/039/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/039/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 001/039",
+  "description": "CBERS4 AWFI camera path 001 row 039 catalog",
+  "title": "CBERS4 AWFI 001/039",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/001/039/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20210819_001_039_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/045/CBERS_4_AWFI_20210819_001_045_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/045/CBERS_4_AWFI_20210819_001_045_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20210819_001_045_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            113.194472,
+            46.439087
+          ],
+          [
+            124.364257,
+            44.730312
+          ],
+          [
+            127.892857,
+            51.237771
+          ],
+          [
+            115.197662,
+            53.184788
+          ],
+          [
+            113.194472,
+            46.439087
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    113.545146,
+    44.307527,
+    128.173647,
+    53.405486
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-08-19T03:05:14Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 159.482,
+    "view:sun_elevation": 51.4597,
+    "view:off_nadir": 0.00586199,
+    "proj:epsg": 32651,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 1,
+    "cbers:row": 45
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/001/045/CBERS_4_AWFI_20210819_001_045_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/001/045/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/001/045/CBERS_4_AWFI_20210819_001_045_L2/CBERS_4_AWFI_20210819_001_045.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/045/CBERS_4_AWFI_20210819_001_045_L2/CBERS_4_AWFI_20210819_001_045_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/045/CBERS_4_AWFI_20210819_001_045_L2/CBERS_4_AWFI_20210819_001_045_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/045/CBERS_4_AWFI_20210819_001_045_L2/CBERS_4_AWFI_20210819_001_045_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/045/CBERS_4_AWFI_20210819_001_045_L2/CBERS_4_AWFI_20210819_001_045_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/001/045/CBERS_4_AWFI_20210819_001_045_L2/CBERS_4_AWFI_20210819_001_045_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/045/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/045/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 001/045",
+  "description": "CBERS4 AWFI camera path 001 row 045 catalog",
+  "title": "CBERS4 AWFI 001/045",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/001/045/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20210819_001_045_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/001/catalog.json
@@ -1,0 +1,37 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 001",
+  "description": "CBERS4 AWFI camera path 001 catalog",
+  "title": "CBERS4 AWFI 001",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/001/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json"
+    },
+    {
+      "rel": "child",
+      "href": "027/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "033/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "039/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "045/catalog.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/075/CBERS_4_AWFI_20201031_003_075_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/075/CBERS_4_AWFI_20201031_003_075_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20201031_003_075_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            105.107256,
+            19.673397
+          ],
+          [
+            113.417788,
+            18.390702
+          ],
+          [
+            115.278169,
+            25.125994
+          ],
+          [
+            106.55857,
+            26.469633
+          ],
+          [
+            105.107256,
+            19.673397
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    105.149248,
+    18.27768,
+    115.344841,
+    26.550512
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-10-31T03:16:39Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 156.091,
+    "view:sun_elevation": 49.7066,
+    "view:off_nadir": 0.00348384,
+    "proj:epsg": 32649,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 3,
+    "cbers:row": 75
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/003/075/CBERS_4_AWFI_20201031_003_075_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/003/075/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/003/075/CBERS_4_AWFI_20201031_003_075_L2/CBERS_4_AWFI_20201031_003_075.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/075/CBERS_4_AWFI_20201031_003_075_L2/CBERS_4_AWFI_20201031_003_075_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/075/CBERS_4_AWFI_20201031_003_075_L2/CBERS_4_AWFI_20201031_003_075_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/075/CBERS_4_AWFI_20201031_003_075_L2/CBERS_4_AWFI_20201031_003_075_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/075/CBERS_4_AWFI_20201031_003_075_L2/CBERS_4_AWFI_20201031_003_075_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/075/CBERS_4_AWFI_20201031_003_075_L2/CBERS_4_AWFI_20201031_003_075_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/075/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/075/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 003/075",
+  "description": "CBERS4 AWFI camera path 003 row 075 catalog",
+  "title": "CBERS4 AWFI 003/075",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/003/075/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20201031_003_075_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/081/CBERS_4_AWFI_20201031_003_081_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/081/CBERS_4_AWFI_20201031_003_081_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20201031_003_081_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            103.975218,
+            14.303771
+          ],
+          [
+            112.065671,
+            13.053541
+          ],
+          [
+            113.793134,
+            19.807263
+          ],
+          [
+            105.409502,
+            21.100804
+          ],
+          [
+            103.975218,
+            14.303771
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    104.00941,
+    12.923114,
+    113.834095,
+    21.247632
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-10-31T03:18:10Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 151.74,
+    "view:sun_elevation": 54.1465,
+    "view:off_nadir": 0.00348384,
+    "proj:epsg": 32649,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 3,
+    "cbers:row": 81
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/003/081/CBERS_4_AWFI_20201031_003_081_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/003/081/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/003/081/CBERS_4_AWFI_20201031_003_081_L2/CBERS_4_AWFI_20201031_003_081.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/081/CBERS_4_AWFI_20201031_003_081_L2/CBERS_4_AWFI_20201031_003_081_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/081/CBERS_4_AWFI_20201031_003_081_L2/CBERS_4_AWFI_20201031_003_081_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/081/CBERS_4_AWFI_20201031_003_081_L2/CBERS_4_AWFI_20201031_003_081_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/081/CBERS_4_AWFI_20201031_003_081_L2/CBERS_4_AWFI_20201031_003_081_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/081/CBERS_4_AWFI_20201031_003_081_L2/CBERS_4_AWFI_20201031_003_081_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/081/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/081/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 003/081",
+  "description": "CBERS4 AWFI camera path 003 row 081 catalog",
+  "title": "CBERS4 AWFI 003/081",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/003/081/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20201031_003_081_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/087/CBERS_4_AWFI_20201031_003_087_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/087/CBERS_4_AWFI_20201031_003_087_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20201031_003_087_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            102.841261,
+            8.937593
+          ],
+          [
+            110.791581,
+            7.70773
+          ],
+          [
+            112.417342,
+            14.476213
+          ],
+          [
+            104.27641,
+            15.733856
+          ],
+          [
+            102.841261,
+            8.937593
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    102.862473,
+    7.591953,
+    112.440847,
+    15.91152
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-10-31T03:19:40Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 146.286,
+    "view:sun_elevation": 58.3159,
+    "view:off_nadir": 0.00348384,
+    "proj:epsg": 32649,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 3,
+    "cbers:row": 87
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/003/087/CBERS_4_AWFI_20201031_003_087_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/003/087/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/003/087/CBERS_4_AWFI_20201031_003_087_L2/CBERS_4_AWFI_20201031_003_087.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/087/CBERS_4_AWFI_20201031_003_087_L2/CBERS_4_AWFI_20201031_003_087_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/087/CBERS_4_AWFI_20201031_003_087_L2/CBERS_4_AWFI_20201031_003_087_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/087/CBERS_4_AWFI_20201031_003_087_L2/CBERS_4_AWFI_20201031_003_087_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/087/CBERS_4_AWFI_20201031_003_087_L2/CBERS_4_AWFI_20201031_003_087_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/087/CBERS_4_AWFI_20201031_003_087_L2/CBERS_4_AWFI_20201031_003_087_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/087/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/087/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 003/087",
+  "description": "CBERS4 AWFI camera path 003 row 087 catalog",
+  "title": "CBERS4 AWFI 003/087",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/003/087/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20201031_003_087_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/093/CBERS_4_AWFI_20201031_003_093_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/093/CBERS_4_AWFI_20201031_003_093_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20201031_003_093_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            101.691406,
+            3.571651
+          ],
+          [
+            109.575389,
+            2.351021
+          ],
+          [
+            111.123545,
+            9.12842
+          ],
+          [
+            103.143398,
+            10.362579
+          ],
+          [
+            101.691406,
+            3.571651
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    101.689152,
+    2.31568,
+    111.158909,
+    10.386886
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-10-31T03:21:10Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 139.317,
+    "view:sun_elevation": 62.1012,
+    "view:off_nadir": 0.00348384,
+    "proj:epsg": 32648,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 3,
+    "cbers:row": 93
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/003/093/CBERS_4_AWFI_20201031_003_093_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/003/093/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/003/093/CBERS_4_AWFI_20201031_003_093_L2/CBERS_4_AWFI_20201031_003_093.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/093/CBERS_4_AWFI_20201031_003_093_L2/CBERS_4_AWFI_20201031_003_093_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/093/CBERS_4_AWFI_20201031_003_093_L2/CBERS_4_AWFI_20201031_003_093_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/093/CBERS_4_AWFI_20201031_003_093_L2/CBERS_4_AWFI_20201031_003_093_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/093/CBERS_4_AWFI_20201031_003_093_L2/CBERS_4_AWFI_20201031_003_093_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/003/093/CBERS_4_AWFI_20201031_003_093_L2/CBERS_4_AWFI_20201031_003_093_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/093/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/093/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 003/093",
+  "description": "CBERS4 AWFI camera path 003 row 093 catalog",
+  "title": "CBERS4 AWFI 003/093",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/003/093/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20201031_003_093_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/003/catalog.json
@@ -1,0 +1,37 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 003",
+  "description": "CBERS4 AWFI camera path 003 catalog",
+  "title": "CBERS4 AWFI 003",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/003/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json"
+    },
+    {
+      "rel": "child",
+      "href": "075/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "081/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "087/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "093/catalog.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/069/CBERS_4_AWFI_20201019_007_069_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/069/CBERS_4_AWFI_20201019_007_069_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20201019_007_069_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            102.385046,
+            25.0396
+          ],
+          [
+            111.00225,
+            23.711481
+          ],
+          [
+            113.034241,
+            30.418487
+          ],
+          [
+            103.87308,
+            31.828267
+          ],
+          [
+            102.385046,
+            25.0396
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    102.484743,
+    23.43923,
+    113.089418,
+    32.089404
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-10-19T03:30:22Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 157.14,
+    "view:sun_elevation": 48.8438,
+    "view:off_nadir": 0.00359777,
+    "proj:epsg": 32649,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 7,
+    "cbers:row": 69
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/069/CBERS_4_AWFI_20201019_007_069_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/069/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/007/069/CBERS_4_AWFI_20201019_007_069_L2/CBERS_4_AWFI_20201019_007_069.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/069/CBERS_4_AWFI_20201019_007_069_L2/CBERS_4_AWFI_20201019_007_069_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/069/CBERS_4_AWFI_20201019_007_069_L2/CBERS_4_AWFI_20201019_007_069_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/069/CBERS_4_AWFI_20201019_007_069_L2/CBERS_4_AWFI_20201019_007_069_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/069/CBERS_4_AWFI_20201019_007_069_L2/CBERS_4_AWFI_20201019_007_069_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/069/CBERS_4_AWFI_20201019_007_069_L2/CBERS_4_AWFI_20201019_007_069_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/069/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/069/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 007/069",
+  "description": "CBERS4 AWFI camera path 007 row 069 catalog",
+  "title": "CBERS4 AWFI 007/069",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/069/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20201019_007_069_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/075/CBERS_4_AWFI_20201019_007_075_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/075/CBERS_4_AWFI_20201019_007_075_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20201019_007_075_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            101.241918,
+            19.672199
+          ],
+          [
+            109.549489,
+            18.39016
+          ],
+          [
+            111.409176,
+            25.123345
+          ],
+          [
+            102.692828,
+            26.466285
+          ],
+          [
+            101.241918,
+            19.672199
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    101.264758,
+    18.369011,
+    111.492791,
+    26.415147
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-10-19T03:31:52Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 152.843,
+    "view:sun_elevation": 53.3181,
+    "view:off_nadir": 0.00359777,
+    "proj:epsg": 32648,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 7,
+    "cbers:row": 75
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/075/CBERS_4_AWFI_20201019_007_075_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/075/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/007/075/CBERS_4_AWFI_20201019_007_075_L2/CBERS_4_AWFI_20201019_007_075.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/075/CBERS_4_AWFI_20201019_007_075_L2/CBERS_4_AWFI_20201019_007_075_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/075/CBERS_4_AWFI_20201019_007_075_L2/CBERS_4_AWFI_20201019_007_075_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/075/CBERS_4_AWFI_20201019_007_075_L2/CBERS_4_AWFI_20201019_007_075_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/075/CBERS_4_AWFI_20201019_007_075_L2/CBERS_4_AWFI_20201019_007_075_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/075/CBERS_4_AWFI_20201019_007_075_L2/CBERS_4_AWFI_20201019_007_075_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/075/CBERS_4_AWFI_20211018_007_075_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/075/CBERS_4_AWFI_20211018_007_075_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20211018_007_075_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            101.194032,
+            19.669646
+          ],
+          [
+            109.501743,
+            18.39308
+          ],
+          [
+            111.356211,
+            25.126833
+          ],
+          [
+            102.639567,
+            26.464033
+          ],
+          [
+            101.194032,
+            19.669646
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    101.216963,
+    18.369799,
+    111.439128,
+    26.415857
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-10-18T03:36:19Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 154.045,
+    "view:sun_elevation": 54.1417,
+    "view:off_nadir": 0.00417989,
+    "proj:epsg": 32648,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 7,
+    "cbers:row": 75
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/075/CBERS_4_AWFI_20211018_007_075_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/075/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/007/075/CBERS_4_AWFI_20211018_007_075_L2/CBERS_4_AWFI_20211018_007_075.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/075/CBERS_4_AWFI_20211018_007_075_L2/CBERS_4_AWFI_20211018_007_075_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/075/CBERS_4_AWFI_20211018_007_075_L2/CBERS_4_AWFI_20211018_007_075_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/075/CBERS_4_AWFI_20211018_007_075_L2/CBERS_4_AWFI_20211018_007_075_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/075/CBERS_4_AWFI_20211018_007_075_L2/CBERS_4_AWFI_20211018_007_075_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/075/CBERS_4_AWFI_20211018_007_075_L2/CBERS_4_AWFI_20211018_007_075_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/075/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/075/catalog.json
@@ -1,0 +1,29 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 007/075",
+  "description": "CBERS4 AWFI camera path 007 row 075 catalog",
+  "title": "CBERS4 AWFI 007/075",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/075/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20201019_007_075_L2.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20211018_007_075_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/081/CBERS_4_AWFI_20201019_007_081_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/081/CBERS_4_AWFI_20201019_007_081_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20201019_007_081_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            100.110461,
+            14.305522
+          ],
+          [
+            108.198141,
+            13.055912
+          ],
+          [
+            109.925149,
+            19.807949
+          ],
+          [
+            101.544436,
+            21.100833
+          ],
+          [
+            100.110461,
+            14.305522
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    100.131145,
+    12.991162,
+    109.981298,
+    21.140754
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-10-19T03:33:23Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 147.534,
+    "view:sun_elevation": 57.543,
+    "view:off_nadir": 0.00359777,
+    "proj:epsg": 32648,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 7,
+    "cbers:row": 81
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/081/CBERS_4_AWFI_20201019_007_081_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/081/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/007/081/CBERS_4_AWFI_20201019_007_081_L2/CBERS_4_AWFI_20201019_007_081.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/081/CBERS_4_AWFI_20201019_007_081_L2/CBERS_4_AWFI_20201019_007_081_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/081/CBERS_4_AWFI_20201019_007_081_L2/CBERS_4_AWFI_20201019_007_081_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/081/CBERS_4_AWFI_20201019_007_081_L2/CBERS_4_AWFI_20201019_007_081_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/081/CBERS_4_AWFI_20201019_007_081_L2/CBERS_4_AWFI_20201019_007_081_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/081/CBERS_4_AWFI_20201019_007_081_L2/CBERS_4_AWFI_20201019_007_081_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/081/CBERS_4_AWFI_20211018_007_081_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/081/CBERS_4_AWFI_20211018_007_081_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20211018_007_081_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            100.066426,
+            14.302431
+          ],
+          [
+            108.154176,
+            13.058154
+          ],
+          [
+            109.876356,
+            19.811028
+          ],
+          [
+            101.495474,
+            21.098391
+          ],
+          [
+            100.066426,
+            14.302431
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    100.08701,
+    12.99206,
+    109.932114,
+    21.140468
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-10-18T03:37:49Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 148.705,
+    "view:sun_elevation": 58.4371,
+    "view:off_nadir": 0.00417989,
+    "proj:epsg": 32648,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 7,
+    "cbers:row": 81
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/081/CBERS_4_AWFI_20211018_007_081_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/081/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/007/081/CBERS_4_AWFI_20211018_007_081_L2/CBERS_4_AWFI_20211018_007_081.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/081/CBERS_4_AWFI_20211018_007_081_L2/CBERS_4_AWFI_20211018_007_081_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/081/CBERS_4_AWFI_20211018_007_081_L2/CBERS_4_AWFI_20211018_007_081_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/081/CBERS_4_AWFI_20211018_007_081_L2/CBERS_4_AWFI_20211018_007_081_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/081/CBERS_4_AWFI_20211018_007_081_L2/CBERS_4_AWFI_20211018_007_081_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/081/CBERS_4_AWFI_20211018_007_081_L2/CBERS_4_AWFI_20211018_007_081_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/081/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/081/catalog.json
@@ -1,0 +1,29 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 007/081",
+  "description": "CBERS4 AWFI camera path 007 row 081 catalog",
+  "title": "CBERS4 AWFI 007/081",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/081/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20201019_007_081_L2.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20211018_007_081_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/087/CBERS_4_AWFI_20201019_007_087_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/087/CBERS_4_AWFI_20201019_007_087_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20201019_007_087_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            98.976027,
+            8.937297
+          ],
+          [
+            106.92359,
+            7.708056
+          ],
+          [
+            108.54894,
+            14.475098
+          ],
+          [
+            100.410923,
+            15.732096
+          ],
+          [
+            98.976027,
+            8.937297
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    98.98991,
+    7.631446,
+    108.584636,
+    15.828814
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-10-19T03:34:53Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 140.8,
+    "view:sun_elevation": 61.406,
+    "view:off_nadir": 0.00359777,
+    "proj:epsg": 32648,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 7,
+    "cbers:row": 87
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/087/CBERS_4_AWFI_20201019_007_087_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/087/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/007/087/CBERS_4_AWFI_20201019_007_087_L2/CBERS_4_AWFI_20201019_007_087.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/087/CBERS_4_AWFI_20201019_007_087_L2/CBERS_4_AWFI_20201019_007_087_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/087/CBERS_4_AWFI_20201019_007_087_L2/CBERS_4_AWFI_20201019_007_087_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/087/CBERS_4_AWFI_20201019_007_087_L2/CBERS_4_AWFI_20201019_007_087_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/087/CBERS_4_AWFI_20201019_007_087_L2/CBERS_4_AWFI_20201019_007_087_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/087/CBERS_4_AWFI_20201019_007_087_L2/CBERS_4_AWFI_20201019_007_087_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/087/CBERS_4_AWFI_20211018_007_087_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/087/CBERS_4_AWFI_20211018_007_087_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20211018_007_087_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            98.935893,
+            8.934793
+          ],
+          [
+            106.883523,
+            7.710776
+          ],
+          [
+            108.504253,
+            14.478588
+          ],
+          [
+            100.366115,
+            15.730227
+          ],
+          [
+            98.935893,
+            8.934793
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    98.949476,
+    7.633759,
+    108.539887,
+    15.828972
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-10-18T03:39:19Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 141.863,
+    "view:sun_elevation": 62.3761,
+    "view:off_nadir": 0.00417989,
+    "proj:epsg": 32648,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 7,
+    "cbers:row": 87
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/087/CBERS_4_AWFI_20211018_007_087_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/087/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/007/087/CBERS_4_AWFI_20211018_007_087_L2/CBERS_4_AWFI_20211018_007_087.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/087/CBERS_4_AWFI_20211018_007_087_L2/CBERS_4_AWFI_20211018_007_087_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/087/CBERS_4_AWFI_20211018_007_087_L2/CBERS_4_AWFI_20211018_007_087_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/087/CBERS_4_AWFI_20211018_007_087_L2/CBERS_4_AWFI_20211018_007_087_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/087/CBERS_4_AWFI_20211018_007_087_L2/CBERS_4_AWFI_20211018_007_087_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/087/CBERS_4_AWFI_20211018_007_087_L2/CBERS_4_AWFI_20211018_007_087_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/087/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/087/catalog.json
@@ -1,0 +1,29 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 007/087",
+  "description": "CBERS4 AWFI camera path 007 row 087 catalog",
+  "title": "CBERS4 AWFI 007/087",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/087/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20201019_007_087_L2.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20211018_007_087_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/093/CBERS_4_AWFI_20211018_007_093_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/093/CBERS_4_AWFI_20211018_007_093_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20211018_007_093_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            97.789313,
+            3.567178
+          ],
+          [
+            105.670664,
+            2.352338
+          ],
+          [
+            107.214413,
+            9.131156
+          ],
+          [
+            99.236981,
+            10.359442
+          ],
+          [
+            97.789313,
+            3.567178
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    97.791091,
+    2.29539,
+    107.236512,
+    10.481797
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-10-18T03:40:50Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 132.994,
+    "view:sun_elevation": 65.7884,
+    "view:off_nadir": 0.00417989,
+    "proj:epsg": 32648,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 7,
+    "cbers:row": 93
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/093/CBERS_4_AWFI_20211018_007_093_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/093/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/007/093/CBERS_4_AWFI_20211018_007_093_L2/CBERS_4_AWFI_20211018_007_093.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/093/CBERS_4_AWFI_20211018_007_093_L2/CBERS_4_AWFI_20211018_007_093_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/093/CBERS_4_AWFI_20211018_007_093_L2/CBERS_4_AWFI_20211018_007_093_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/093/CBERS_4_AWFI_20211018_007_093_L2/CBERS_4_AWFI_20211018_007_093_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/093/CBERS_4_AWFI_20211018_007_093_L2/CBERS_4_AWFI_20211018_007_093_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/007/093/CBERS_4_AWFI_20211018_007_093_L2/CBERS_4_AWFI_20211018_007_093_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/093/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/093/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 007/093",
+  "description": "CBERS4 AWFI camera path 007 row 093 catalog",
+  "title": "CBERS4 AWFI 007/093",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/093/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20211018_007_093_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/007/catalog.json
@@ -1,0 +1,41 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 007",
+  "description": "CBERS4 AWFI camera path 007 catalog",
+  "title": "CBERS4 AWFI 007",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/007/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json"
+    },
+    {
+      "rel": "child",
+      "href": "069/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "075/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "081/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "087/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "093/catalog.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/063/CBERS_4_AWFI_20210930_013_063_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/063/CBERS_4_AWFI_20210930_013_063_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20210930_013_063_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            97.712131,
+            30.396546
+          ],
+          [
+            106.741399,
+            29.013503
+          ],
+          [
+            108.994728,
+            35.691891
+          ],
+          [
+            99.257105,
+            37.181585
+          ],
+          [
+            97.712131,
+            30.396546
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    97.818017,
+    28.794372,
+    109.099467,
+    37.327898
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-09-30T03:56:23Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 157.176,
+    "view:sun_elevation": 51.0611,
+    "view:off_nadir": 0.00285369,
+    "proj:epsg": 32648,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 13,
+    "cbers:row": 63
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/013/063/CBERS_4_AWFI_20210930_013_063_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/013/063/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/013/063/CBERS_4_AWFI_20210930_013_063_L2/CBERS_4_AWFI_20210930_013_063.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/063/CBERS_4_AWFI_20210930_013_063_L2/CBERS_4_AWFI_20210930_013_063_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/063/CBERS_4_AWFI_20210930_013_063_L2/CBERS_4_AWFI_20210930_013_063_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/063/CBERS_4_AWFI_20210930_013_063_L2/CBERS_4_AWFI_20210930_013_063_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/063/CBERS_4_AWFI_20210930_013_063_L2/CBERS_4_AWFI_20210930_013_063_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/063/CBERS_4_AWFI_20210930_013_063_L2/CBERS_4_AWFI_20210930_013_063_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/063/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/063/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 013/063",
+  "description": "CBERS4 AWFI camera path 013 row 063 catalog",
+  "title": "CBERS4 AWFI 013/063",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/013/063/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20210930_013_063_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/069/CBERS_4_AWFI_20210930_013_069_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/069/CBERS_4_AWFI_20210930_013_069_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20210930_013_069_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            96.547318,
+            25.035268
+          ],
+          [
+            105.162488,
+            23.714029
+          ],
+          [
+            107.18931,
+            30.4225
+          ],
+          [
+            98.02953,
+            31.825111
+          ],
+          [
+            96.547318,
+            25.035268
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    96.643884,
+    23.45019,
+    107.246356,
+    32.074596
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-09-30T03:57:53Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 152.334,
+    "view:sun_elevation": 55.4957,
+    "view:off_nadir": 0.00285369,
+    "proj:epsg": 32648,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 13,
+    "cbers:row": 69
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/013/069/CBERS_4_AWFI_20210930_013_069_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/013/069/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/013/069/CBERS_4_AWFI_20210930_013_069_L2/CBERS_4_AWFI_20210930_013_069.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/069/CBERS_4_AWFI_20210930_013_069_L2/CBERS_4_AWFI_20210930_013_069_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/069/CBERS_4_AWFI_20210930_013_069_L2/CBERS_4_AWFI_20210930_013_069_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/069/CBERS_4_AWFI_20210930_013_069_L2/CBERS_4_AWFI_20210930_013_069_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/069/CBERS_4_AWFI_20210930_013_069_L2/CBERS_4_AWFI_20210930_013_069_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/069/CBERS_4_AWFI_20210930_013_069_L2/CBERS_4_AWFI_20210930_013_069_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/069/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/069/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 013/069",
+  "description": "CBERS4 AWFI camera path 013 row 069 catalog",
+  "title": "CBERS4 AWFI 013/069",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/013/069/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20210930_013_069_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/075/CBERS_4_AWFI_20210930_013_075_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/075/CBERS_4_AWFI_20210930_013_075_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20210930_013_075_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            95.40874,
+            19.668859
+          ],
+          [
+            103.713984,
+            18.393529
+          ],
+          [
+            105.568758,
+            25.127517
+          ],
+          [
+            96.854228,
+            26.463545
+          ],
+          [
+            95.40874,
+            19.668859
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    95.430265,
+    18.379699,
+    105.653152,
+    26.402566
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-09-30T03:59:24Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 146.337,
+    "view:sun_elevation": 59.6482,
+    "view:off_nadir": 0.00285369,
+    "proj:epsg": 32647,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 13,
+    "cbers:row": 75
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/013/075/CBERS_4_AWFI_20210930_013_075_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/013/075/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/013/075/CBERS_4_AWFI_20210930_013_075_L2/CBERS_4_AWFI_20210930_013_075.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/075/CBERS_4_AWFI_20210930_013_075_L2/CBERS_4_AWFI_20210930_013_075_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/075/CBERS_4_AWFI_20210930_013_075_L2/CBERS_4_AWFI_20210930_013_075_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/075/CBERS_4_AWFI_20210930_013_075_L2/CBERS_4_AWFI_20210930_013_075_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/075/CBERS_4_AWFI_20210930_013_075_L2/CBERS_4_AWFI_20210930_013_075_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/075/CBERS_4_AWFI_20210930_013_075_L2/CBERS_4_AWFI_20210930_013_075_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/075/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/075/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 013/075",
+  "description": "CBERS4 AWFI camera path 013 row 075 catalog",
+  "title": "CBERS4 AWFI 013/075",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/013/075/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20210930_013_075_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/081/CBERS_4_AWFI_20210930_013_081_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/081/CBERS_4_AWFI_20210930_013_081_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20210930_013_081_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            94.281016,
+            14.300719
+          ],
+          [
+            102.366046,
+            13.057713
+          ],
+          [
+            104.088649,
+            19.811503
+          ],
+          [
+            95.71017,
+            21.097653
+          ],
+          [
+            94.281016,
+            14.300719
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    94.300444,
+    12.998325,
+    104.145623,
+    21.129486
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-09-30T04:00:54Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 138.698,
+    "view:sun_elevation": 63.3821,
+    "view:off_nadir": 0.00285369,
+    "proj:epsg": 32647,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 13,
+    "cbers:row": 81
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/013/081/CBERS_4_AWFI_20210930_013_081_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/013/081/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/013/081/CBERS_4_AWFI_20210930_013_081_L2/CBERS_4_AWFI_20210930_013_081.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/081/CBERS_4_AWFI_20210930_013_081_L2/CBERS_4_AWFI_20210930_013_081_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/081/CBERS_4_AWFI_20210930_013_081_L2/CBERS_4_AWFI_20210930_013_081_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/081/CBERS_4_AWFI_20210930_013_081_L2/CBERS_4_AWFI_20210930_013_081_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/081/CBERS_4_AWFI_20210930_013_081_L2/CBERS_4_AWFI_20210930_013_081_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/013/081/CBERS_4_AWFI_20210930_013_081_L2/CBERS_4_AWFI_20210930_013_081_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/081/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/081/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 013/081",
+  "description": "CBERS4 AWFI camera path 013 row 081 catalog",
+  "title": "CBERS4 AWFI 013/081",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/013/081/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20210930_013_081_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/013/catalog.json
@@ -1,0 +1,37 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 013",
+  "description": "CBERS4 AWFI camera path 013 catalog",
+  "title": "CBERS4 AWFI 013",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/013/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json"
+    },
+    {
+      "rel": "child",
+      "href": "063/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "069/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "075/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "081/catalog.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/033/CBERS_4_AWFI_20210415_017_033_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/033/CBERS_4_AWFI_20210415_017_033_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20210415_017_033_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            101.114302,
+            57.076851
+          ],
+          [
+            114.964132,
+            54.94462
+          ],
+          [
+            120.530459,
+            61.209651
+          ],
+          [
+            104.005613,
+            63.784386
+          ],
+          [
+            101.114302,
+            57.076851
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    101.704633,
+    54.614202,
+    121.404332,
+    63.653024
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-04-15T04:02:52Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 171.266,
+    "view:sun_elevation": 39.0773,
+    "view:off_nadir": 0.0066551,
+    "proj:epsg": 32649,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 17,
+    "cbers:row": 33
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/017/033/CBERS_4_AWFI_20210415_017_033_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/017/033/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/017/033/CBERS_4_AWFI_20210415_017_033_L2/CBERS_4_AWFI_20210415_017_033.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/033/CBERS_4_AWFI_20210415_017_033_L2/CBERS_4_AWFI_20210415_017_033_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/033/CBERS_4_AWFI_20210415_017_033_L2/CBERS_4_AWFI_20210415_017_033_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/033/CBERS_4_AWFI_20210415_017_033_L2/CBERS_4_AWFI_20210415_017_033_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/033/CBERS_4_AWFI_20210415_017_033_L2/CBERS_4_AWFI_20210415_017_033_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/033/CBERS_4_AWFI_20210415_017_033_L2/CBERS_4_AWFI_20210415_017_033_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/033/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/033/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 017/033",
+  "description": "CBERS4 AWFI camera path 017 row 033 catalog",
+  "title": "CBERS4 AWFI 017/033",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/017/033/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20210415_017_033_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/039/CBERS_4_AWFI_20210415_017_039_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/039/CBERS_4_AWFI_20210415_017_039_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20210415_017_039_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            99.313366,
+            51.766212
+          ],
+          [
+            111.643934,
+            49.875716
+          ],
+          [
+            115.986915,
+            56.280756
+          ],
+          [
+            101.653949,
+            58.491183
+          ],
+          [
+            99.313366,
+            51.766212
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    99.895565,
+    49.303873,
+    116.390087,
+    58.795254
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-04-15T04:04:23Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 166.334,
+    "view:sun_elevation": 43.9608,
+    "view:off_nadir": 0.0066551,
+    "proj:epsg": 32649,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 17,
+    "cbers:row": 39
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/017/039/CBERS_4_AWFI_20210415_017_039_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/017/039/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/017/039/CBERS_4_AWFI_20210415_017_039_L2/CBERS_4_AWFI_20210415_017_039.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/039/CBERS_4_AWFI_20210415_017_039_L2/CBERS_4_AWFI_20210415_017_039_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/039/CBERS_4_AWFI_20210415_017_039_L2/CBERS_4_AWFI_20210415_017_039_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/039/CBERS_4_AWFI_20210415_017_039_L2/CBERS_4_AWFI_20210415_017_039_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/039/CBERS_4_AWFI_20210415_017_039_L2/CBERS_4_AWFI_20210415_017_039_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/039/CBERS_4_AWFI_20210415_017_039_L2/CBERS_4_AWFI_20210415_017_039_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/039/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/039/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 017/039",
+  "description": "CBERS4 AWFI camera path 017 row 039 catalog",
+  "title": "CBERS4 AWFI 017/039",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/017/039/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20210415_017_039_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/045/CBERS_4_AWFI_20210415_017_045_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/045/CBERS_4_AWFI_20210415_017_045_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20210415_017_045_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            97.76066,
+            46.43963
+          ],
+          [
+            108.931424,
+            44.729872
+          ],
+          [
+            112.460503,
+            51.236377
+          ],
+          [
+            99.764747,
+            53.184436
+          ],
+          [
+            97.76066,
+            46.43963
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    97.987818,
+    44.543606,
+    112.81505,
+    53.119765
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-04-15T04:05:53Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 161.508,
+    "view:sun_elevation": 48.6777,
+    "view:off_nadir": 0.0066551,
+    "proj:epsg": 32648,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 17,
+    "cbers:row": 45
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/017/045/CBERS_4_AWFI_20210415_017_045_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/017/045/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/017/045/CBERS_4_AWFI_20210415_017_045_L2/CBERS_4_AWFI_20210415_017_045.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/045/CBERS_4_AWFI_20210415_017_045_L2/CBERS_4_AWFI_20210415_017_045_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/045/CBERS_4_AWFI_20210415_017_045_L2/CBERS_4_AWFI_20210415_017_045_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/045/CBERS_4_AWFI_20210415_017_045_L2/CBERS_4_AWFI_20210415_017_045_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/045/CBERS_4_AWFI_20210415_017_045_L2/CBERS_4_AWFI_20210415_017_045_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/045/CBERS_4_AWFI_20210415_017_045_L2/CBERS_4_AWFI_20210415_017_045_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/045/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/045/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 017/045",
+  "description": "CBERS4 AWFI camera path 017 row 045 catalog",
+  "title": "CBERS4 AWFI 017/045",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/017/045/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20210415_017_045_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/051/CBERS_4_AWFI_20210415_017_051_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/051/CBERS_4_AWFI_20210415_017_051_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20210415_017_051_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            96.369539,
+            41.100585
+          ],
+          [
+            106.644502,
+            39.528395
+          ],
+          [
+            109.607198,
+            46.108547
+          ],
+          [
+            98.156172,
+            47.861703
+          ],
+          [
+            96.369539,
+            41.100585
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    96.596718,
+    39.197493,
+    109.804859,
+    48.042701
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2021-04-15T04:07:23Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 156.329,
+    "view:sun_elevation": 53.2011,
+    "view:off_nadir": 0.0066551,
+    "proj:epsg": 32648,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 17,
+    "cbers:row": 51
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/017/051/CBERS_4_AWFI_20210415_017_051_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/017/051/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/017/051/CBERS_4_AWFI_20210415_017_051_L2/CBERS_4_AWFI_20210415_017_051.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/051/CBERS_4_AWFI_20210415_017_051_L2/CBERS_4_AWFI_20210415_017_051_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/051/CBERS_4_AWFI_20210415_017_051_L2/CBERS_4_AWFI_20210415_017_051_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/051/CBERS_4_AWFI_20210415_017_051_L2/CBERS_4_AWFI_20210415_017_051_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/051/CBERS_4_AWFI_20210415_017_051_L2/CBERS_4_AWFI_20210415_017_051_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/017/051/CBERS_4_AWFI_20210415_017_051_L2/CBERS_4_AWFI_20210415_017_051_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/051/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/051/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 017/051",
+  "description": "CBERS4 AWFI camera path 017 row 051 catalog",
+  "title": "CBERS4 AWFI 017/051",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/017/051/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20210415_017_051_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/017/catalog.json
@@ -1,0 +1,37 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 017",
+  "description": "CBERS4 AWFI camera path 017 catalog",
+  "title": "CBERS4 AWFI 017",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/017/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json"
+    },
+    {
+      "rel": "child",
+      "href": "033/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "039/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "045/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "051/catalog.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/019/033/CBERS_4_AWFI_20190629_019_033_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/019/033/CBERS_4_AWFI_20190629_019_033_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20190629_019_033_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            99.292836,
+            57.089749
+          ],
+          [
+            113.123372,
+            54.9391
+          ],
+          [
+            118.709882,
+            61.18933
+          ],
+          [
+            102.221592,
+            63.784994
+          ],
+          [
+            99.292836,
+            57.089749
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    100.052824,
+    54.423057,
+    119.502721,
+    63.877216
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2019-06-29T03:51:52Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 161.625,
+    "view:sun_elevation": 51.8449,
+    "view:off_nadir": 0.00647037,
+    "proj:epsg": 32649,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 19,
+    "cbers:row": 33
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/019/033/CBERS_4_AWFI_20190629_019_033_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/019/033/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/019/033/CBERS_4_AWFI_20190629_019_033_L2/CBERS_4_AWFI_20190629_019_033.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/019/033/CBERS_4_AWFI_20190629_019_033_L2/CBERS_4_AWFI_20190629_019_033_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/019/033/CBERS_4_AWFI_20190629_019_033_L2/CBERS_4_AWFI_20190629_019_033_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/019/033/CBERS_4_AWFI_20190629_019_033_L2/CBERS_4_AWFI_20190629_019_033_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/019/033/CBERS_4_AWFI_20190629_019_033_L2/CBERS_4_AWFI_20190629_019_033_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/019/033/CBERS_4_AWFI_20190629_019_033_L2/CBERS_4_AWFI_20190629_019_033_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/019/033/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/019/033/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 019/033",
+  "description": "CBERS4 AWFI camera path 019 row 033 catalog",
+  "title": "CBERS4 AWFI 019/033",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/019/033/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20190629_019_033_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/019/039/CBERS_4_AWFI_20190629_019_039_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/019/039/CBERS_4_AWFI_20190629_019_039_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20190629_019_039_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            97.466982,
+            51.776981
+          ],
+          [
+            109.782666,
+            49.870085
+          ],
+          [
+            114.149419,
+            56.271226
+          ],
+          [
+            99.838782,
+            58.500498
+          ],
+          [
+            97.466982,
+            51.776981
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    97.778822,
+    49.705325,
+    114.713627,
+    58.311533
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2019-06-29T03:53:23Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 154.156,
+    "view:sun_elevation": 56.1373,
+    "view:off_nadir": 0.00647037,
+    "proj:epsg": 32648,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 19,
+    "cbers:row": 39
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/019/039/CBERS_4_AWFI_20190629_019_039_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/019/039/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/019/039/CBERS_4_AWFI_20190629_019_039_L2/CBERS_4_AWFI_20190629_019_039.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/019/039/CBERS_4_AWFI_20190629_019_039_L2/CBERS_4_AWFI_20190629_019_039_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/019/039/CBERS_4_AWFI_20190629_019_039_L2/CBERS_4_AWFI_20190629_019_039_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/019/039/CBERS_4_AWFI_20190629_019_039_L2/CBERS_4_AWFI_20190629_019_039_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/019/039/CBERS_4_AWFI_20190629_019_039_L2/CBERS_4_AWFI_20190629_019_039_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/019/039/CBERS_4_AWFI_20190629_019_039_L2/CBERS_4_AWFI_20190629_019_039_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/019/039/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/019/039/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 019/039",
+  "description": "CBERS4 AWFI camera path 019 row 039 catalog",
+  "title": "CBERS4 AWFI 019/039",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/019/039/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20190629_019_039_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/019/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/019/catalog.json
@@ -1,0 +1,29 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 019",
+  "description": "CBERS4 AWFI camera path 019 catalog",
+  "title": "CBERS4 AWFI 019",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/019/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json"
+    },
+    {
+      "rel": "child",
+      "href": "033/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "039/catalog.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/021/051/CBERS_4_AWFI_20200717_021_051_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/021/051/CBERS_4_AWFI_20200717_021_051_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20200717_021_051_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            92.499535,
+            41.106076
+          ],
+          [
+            102.772233,
+            39.526817
+          ],
+          [
+            105.741514,
+            46.104592
+          ],
+          [
+            94.295093,
+            47.865333
+          ],
+          [
+            92.499535,
+            41.106076
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    92.653133,
+    39.376265,
+    105.986969,
+    47.825987
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-07-17T04:17:51Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 143.651,
+    "view:sun_elevation": 62.8123,
+    "view:off_nadir": 0.00565223,
+    "proj:epsg": 32647,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 21,
+    "cbers:row": 51
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/021/051/CBERS_4_AWFI_20200717_021_051_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/021/051/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/021/051/CBERS_4_AWFI_20200717_021_051_L2/CBERS_4_AWFI_20200717_021_051.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/021/051/CBERS_4_AWFI_20200717_021_051_L2/CBERS_4_AWFI_20200717_021_051_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/021/051/CBERS_4_AWFI_20200717_021_051_L2/CBERS_4_AWFI_20200717_021_051_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/021/051/CBERS_4_AWFI_20200717_021_051_L2/CBERS_4_AWFI_20200717_021_051_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/021/051/CBERS_4_AWFI_20200717_021_051_L2/CBERS_4_AWFI_20200717_021_051_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/021/051/CBERS_4_AWFI_20200717_021_051_L2/CBERS_4_AWFI_20200717_021_051_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/021/051/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/021/051/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 021/051",
+  "description": "CBERS4 AWFI camera path 021 row 051 catalog",
+  "title": "CBERS4 AWFI 021/051",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/021/051/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20200717_021_051_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/021/057/CBERS_4_AWFI_20200717_021_057_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/021/057/CBERS_4_AWFI_20200717_021_057_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20200717_021_057_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            91.209947,
+            35.757565
+          ],
+          [
+            100.787775,
+            34.284352
+          ],
+          [
+            103.348401,
+            40.915879
+          ],
+          [
+            92.859323,
+            42.528368
+          ],
+          [
+            91.209947,
+            35.757565
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    91.363133,
+    34.020561,
+    103.493015,
+    42.682557
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-07-17T04:19:21Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 133.412,
+    "view:sun_elevation": 66.0681,
+    "view:off_nadir": 0.00565223,
+    "proj:epsg": 32647,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 21,
+    "cbers:row": 57
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/021/057/CBERS_4_AWFI_20200717_021_057_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/021/057/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/021/057/CBERS_4_AWFI_20200717_021_057_L2/CBERS_4_AWFI_20200717_021_057.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/021/057/CBERS_4_AWFI_20200717_021_057_L2/CBERS_4_AWFI_20200717_021_057_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/021/057/CBERS_4_AWFI_20200717_021_057_L2/CBERS_4_AWFI_20200717_021_057_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/021/057/CBERS_4_AWFI_20200717_021_057_L2/CBERS_4_AWFI_20200717_021_057_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/021/057/CBERS_4_AWFI_20200717_021_057_L2/CBERS_4_AWFI_20200717_021_057_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/021/057/CBERS_4_AWFI_20200717_021_057_L2/CBERS_4_AWFI_20200717_021_057_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/021/057/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/021/057/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 021/057",
+  "description": "CBERS4 AWFI camera path 021 row 057 catalog",
+  "title": "CBERS4 AWFI 021/057",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/021/057/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20200717_021_057_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/021/063/CBERS_4_AWFI_20200717_021_063_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/021/063/CBERS_4_AWFI_20200717_021_063_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20200717_021_063_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            89.992957,
+            30.402401
+          ],
+          [
+            99.031576,
+            29.010742
+          ],
+          [
+            101.291091,
+            35.683652
+          ],
+          [
+            91.544971,
+            37.18246
+          ],
+          [
+            89.992957,
+            30.402401
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    90.136198,
+    28.680122,
+    101.365894,
+    37.471642
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-07-17T04:20:51Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 120.905,
+    "view:sun_elevation": 68.4741,
+    "view:off_nadir": 0.00565223,
+    "proj:epsg": 32647,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 21,
+    "cbers:row": 63
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/021/063/CBERS_4_AWFI_20200717_021_063_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/021/063/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/021/063/CBERS_4_AWFI_20200717_021_063_L2/CBERS_4_AWFI_20200717_021_063.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/021/063/CBERS_4_AWFI_20200717_021_063_L2/CBERS_4_AWFI_20200717_021_063_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/021/063/CBERS_4_AWFI_20200717_021_063_L2/CBERS_4_AWFI_20200717_021_063_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/021/063/CBERS_4_AWFI_20200717_021_063_L2/CBERS_4_AWFI_20200717_021_063_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/021/063/CBERS_4_AWFI_20200717_021_063_L2/CBERS_4_AWFI_20200717_021_063_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/021/063/CBERS_4_AWFI_20200717_021_063_L2/CBERS_4_AWFI_20200717_021_063_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/021/063/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/021/063/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 021/063",
+  "description": "CBERS4 AWFI camera path 021 row 063 catalog",
+  "title": "CBERS4 AWFI 021/063",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/021/063/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20200717_021_063_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/021/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/021/catalog.json
@@ -1,0 +1,33 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 021",
+  "description": "CBERS4 AWFI camera path 021 catalog",
+  "title": "CBERS4 AWFI 021",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/021/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json"
+    },
+    {
+      "rel": "child",
+      "href": "051/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "057/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "063/catalog.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/063/CBERS_4_AWFI_20200523_022_063_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/063/CBERS_4_AWFI_20200523_022_063_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20200523_022_063_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            89.013777,
+            30.401572
+          ],
+          [
+            98.042955,
+            29.009996
+          ],
+          [
+            100.303255,
+            35.684472
+          ],
+          [
+            90.566317,
+            37.183269
+          ],
+          [
+            89.013777,
+            30.401572
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    89.060797,
+    29.008176,
+    100.44902,
+    37.051149
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-05-23T04:23:19Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 125.456,
+    "view:sun_elevation": 69.5076,
+    "view:off_nadir": 0.00267785,
+    "proj:epsg": 32646,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 22,
+    "cbers:row": 63
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/022/063/CBERS_4_AWFI_20200523_022_063_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/022/063/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/022/063/CBERS_4_AWFI_20200523_022_063_L2/CBERS_4_AWFI_20200523_022_063.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/063/CBERS_4_AWFI_20200523_022_063_L2/CBERS_4_AWFI_20200523_022_063_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/063/CBERS_4_AWFI_20200523_022_063_L2/CBERS_4_AWFI_20200523_022_063_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/063/CBERS_4_AWFI_20200523_022_063_L2/CBERS_4_AWFI_20200523_022_063_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/063/CBERS_4_AWFI_20200523_022_063_L2/CBERS_4_AWFI_20200523_022_063_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/063/CBERS_4_AWFI_20200523_022_063_L2/CBERS_4_AWFI_20200523_022_063_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/063/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/063/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 022/063",
+  "description": "CBERS4 AWFI camera path 022 row 063 catalog",
+  "title": "CBERS4 AWFI 022/063",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/022/063/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20200523_022_063_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/069/CBERS_4_AWFI_20200523_022_069_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/069/CBERS_4_AWFI_20200523_022_069_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20200523_022_069_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            87.842907,
+            25.039162
+          ],
+          [
+            96.457967,
+            23.709764
+          ],
+          [
+            98.491724,
+            30.416503
+          ],
+          [
+            89.332288,
+            31.827726
+          ],
+          [
+            87.842907,
+            25.039162
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    87.892918,
+    23.625368,
+    98.590255,
+    31.835119
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-05-23T04:24:49Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 110.272,
+    "view:sun_elevation": 71.1584,
+    "view:off_nadir": 0.00267785,
+    "proj:epsg": 32646,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 22,
+    "cbers:row": 69
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/022/069/CBERS_4_AWFI_20200523_022_069_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/022/069/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/022/069/CBERS_4_AWFI_20200523_022_069_L2/CBERS_4_AWFI_20200523_022_069.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/069/CBERS_4_AWFI_20200523_022_069_L2/CBERS_4_AWFI_20200523_022_069_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/069/CBERS_4_AWFI_20200523_022_069_L2/CBERS_4_AWFI_20200523_022_069_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/069/CBERS_4_AWFI_20200523_022_069_L2/CBERS_4_AWFI_20200523_022_069_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/069/CBERS_4_AWFI_20200523_022_069_L2/CBERS_4_AWFI_20200523_022_069_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/069/CBERS_4_AWFI_20200523_022_069_L2/CBERS_4_AWFI_20200523_022_069_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/069/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/069/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 022/069",
+  "description": "CBERS4 AWFI camera path 022 row 069 catalog",
+  "title": "CBERS4 AWFI 022/069",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/022/069/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20200523_022_069_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/075/CBERS_4_AWFI_20200523_022_075_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/075/CBERS_4_AWFI_20200523_022_075_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20200523_022_075_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            86.699392,
+            19.674508
+          ],
+          [
+            95.004617,
+            18.391287
+          ],
+          [
+            96.865804,
+            25.123465
+          ],
+          [
+            88.151372,
+            26.467739
+          ],
+          [
+            86.699392,
+            19.674508
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    86.745395,
+    18.260248,
+    96.928659,
+    26.574156
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-05-23T04:26:20Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 93.7303,
+    "view:sun_elevation": 71.3738,
+    "view:off_nadir": 0.00267785,
+    "proj:epsg": 32646,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 22,
+    "cbers:row": 75
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/022/075/CBERS_4_AWFI_20200523_022_075_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/022/075/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/022/075/CBERS_4_AWFI_20200523_022_075_L2/CBERS_4_AWFI_20200523_022_075.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/075/CBERS_4_AWFI_20200523_022_075_L2/CBERS_4_AWFI_20200523_022_075_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/075/CBERS_4_AWFI_20200523_022_075_L2/CBERS_4_AWFI_20200523_022_075_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/075/CBERS_4_AWFI_20200523_022_075_L2/CBERS_4_AWFI_20200523_022_075_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/075/CBERS_4_AWFI_20200523_022_075_L2/CBERS_4_AWFI_20200523_022_075_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/075/CBERS_4_AWFI_20200523_022_075_L2/CBERS_4_AWFI_20200523_022_075_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/075/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/075/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 022/075",
+  "description": "CBERS4 AWFI camera path 022 row 075 catalog",
+  "title": "CBERS4 AWFI 022/075",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/022/075/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20200523_022_075_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/081/CBERS_4_AWFI_20200523_022_081_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/081/CBERS_4_AWFI_20200523_022_081_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20200523_022_081_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            85.566644,
+            14.306054
+          ],
+          [
+            93.651557,
+            13.055369
+          ],
+          [
+            95.380176,
+            19.80735
+          ],
+          [
+            87.001802,
+            21.101441
+          ],
+          [
+            85.566644,
+            14.306054
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    85.603183,
+    12.91187,
+    95.417784,
+    21.268567
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-05-23T04:27:50Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 78.2015,
+    "view:sun_elevation": 70.1034,
+    "view:off_nadir": 0.00267785,
+    "proj:epsg": 32646,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 22,
+    "cbers:row": 81
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/022/081/CBERS_4_AWFI_20200523_022_081_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/022/081/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/022/081/CBERS_4_AWFI_20200523_022_081_L2/CBERS_4_AWFI_20200523_022_081.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/081/CBERS_4_AWFI_20200523_022_081_L2/CBERS_4_AWFI_20200523_022_081_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/081/CBERS_4_AWFI_20200523_022_081_L2/CBERS_4_AWFI_20200523_022_081_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/081/CBERS_4_AWFI_20200523_022_081_L2/CBERS_4_AWFI_20200523_022_081_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/081/CBERS_4_AWFI_20200523_022_081_L2/CBERS_4_AWFI_20200523_022_081_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/022/081/CBERS_4_AWFI_20200523_022_081_L2/CBERS_4_AWFI_20200523_022_081_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/081/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/081/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 022/081",
+  "description": "CBERS4 AWFI camera path 022 row 081 catalog",
+  "title": "CBERS4 AWFI 022/081",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/022/081/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20200523_022_081_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/022/catalog.json
@@ -1,0 +1,37 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 022",
+  "description": "CBERS4 AWFI camera path 022 catalog",
+  "title": "CBERS4 AWFI 022",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/022/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json"
+    },
+    {
+      "rel": "child",
+      "href": "063/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "069/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "075/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "081/catalog.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/063/CBERS_4_AWFI_20200520_023_063_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/063/CBERS_4_AWFI_20200520_023_063_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20200520_023_063_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            88.048631,
+            30.401665
+          ],
+          [
+            97.078312,
+            29.00997
+          ],
+          [
+            99.338843,
+            35.684624
+          ],
+          [
+            89.601257,
+            37.183569
+          ],
+          [
+            88.048631,
+            30.401665
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    88.111815,
+    28.944098,
+    99.47546,
+    37.132769
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-05-20T04:27:06Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 126.735,
+    "view:sun_elevation": 69.1181,
+    "view:off_nadir": 0.0022774,
+    "proj:epsg": 32646,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 23,
+    "cbers:row": 63
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/023/063/CBERS_4_AWFI_20200520_023_063_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/023/063/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/023/063/CBERS_4_AWFI_20200520_023_063_L2/CBERS_4_AWFI_20200520_023_063.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/063/CBERS_4_AWFI_20200520_023_063_L2/CBERS_4_AWFI_20200520_023_063_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/063/CBERS_4_AWFI_20200520_023_063_L2/CBERS_4_AWFI_20200520_023_063_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/063/CBERS_4_AWFI_20200520_023_063_L2/CBERS_4_AWFI_20200520_023_063_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/063/CBERS_4_AWFI_20200520_023_063_L2/CBERS_4_AWFI_20200520_023_063_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/063/CBERS_4_AWFI_20200520_023_063_L2/CBERS_4_AWFI_20200520_023_063_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/063/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/063/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 023/063",
+  "description": "CBERS4 AWFI camera path 023 row 063 catalog",
+  "title": "CBERS4 AWFI 023/063",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/023/063/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20200520_023_063_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/069/CBERS_4_AWFI_20200520_023_069_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/069/CBERS_4_AWFI_20200520_023_069_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20200520_023_069_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            86.877908,
+            25.040021
+          ],
+          [
+            95.493429,
+            23.710522
+          ],
+          [
+            97.527414,
+            30.417395
+          ],
+          [
+            88.367359,
+            31.828759
+          ],
+          [
+            86.877908,
+            25.040021
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    86.940331,
+    23.573149,
+    97.615528,
+    31.907193
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-05-20T04:28:36Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 111.931,
+    "view:sun_elevation": 70.9018,
+    "view:off_nadir": 0.0022774,
+    "proj:epsg": 32646,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 23,
+    "cbers:row": 69
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/023/069/CBERS_4_AWFI_20200520_023_069_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/023/069/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/023/069/CBERS_4_AWFI_20200520_023_069_L2/CBERS_4_AWFI_20200520_023_069.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/069/CBERS_4_AWFI_20200520_023_069_L2/CBERS_4_AWFI_20200520_023_069_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/069/CBERS_4_AWFI_20200520_023_069_L2/CBERS_4_AWFI_20200520_023_069_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/069/CBERS_4_AWFI_20200520_023_069_L2/CBERS_4_AWFI_20200520_023_069_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/069/CBERS_4_AWFI_20200520_023_069_L2/CBERS_4_AWFI_20200520_023_069_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/069/CBERS_4_AWFI_20200520_023_069_L2/CBERS_4_AWFI_20200520_023_069_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/069/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/069/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 023/069",
+  "description": "CBERS4 AWFI camera path 023 row 069 catalog",
+  "title": "CBERS4 AWFI 023/069",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/023/069/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20200520_023_069_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/075/CBERS_4_AWFI_20200520_023_075_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/075/CBERS_4_AWFI_20200520_023_075_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20200520_023_075_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            85.733992,
+            19.67358
+          ],
+          [
+            94.039493,
+            18.39028
+          ],
+          [
+            95.900801,
+            25.122511
+          ],
+          [
+            87.186006,
+            26.466875
+          ],
+          [
+            85.733992,
+            19.67358
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    85.789823,
+    18.217883,
+    95.953748,
+    26.632967
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-05-20T04:30:06Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 95.5673,
+    "view:sun_elevation": 71.281,
+    "view:off_nadir": 0.0022774,
+    "proj:epsg": 32646,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 23,
+    "cbers:row": 75
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/023/075/CBERS_4_AWFI_20200520_023_075_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/023/075/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/023/075/CBERS_4_AWFI_20200520_023_075_L2/CBERS_4_AWFI_20200520_023_075.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/075/CBERS_4_AWFI_20200520_023_075_L2/CBERS_4_AWFI_20200520_023_075_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/075/CBERS_4_AWFI_20200520_023_075_L2/CBERS_4_AWFI_20200520_023_075_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/075/CBERS_4_AWFI_20200520_023_075_L2/CBERS_4_AWFI_20200520_023_075_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/075/CBERS_4_AWFI_20200520_023_075_L2/CBERS_4_AWFI_20200520_023_075_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/075/CBERS_4_AWFI_20200520_023_075_L2/CBERS_4_AWFI_20200520_023_075_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/075/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/075/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 023/075",
+  "description": "CBERS4 AWFI camera path 023 row 075 catalog",
+  "title": "CBERS4 AWFI 023/075",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/023/075/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20200520_023_075_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/081/CBERS_4_AWFI_20200520_023_081_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/081/CBERS_4_AWFI_20200520_023_081_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20200520_023_081_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            84.601359,
+            14.305759
+          ],
+          [
+            92.686511,
+            13.055011
+          ],
+          [
+            94.415355,
+            19.807391
+          ],
+          [
+            86.03663,
+            21.101568
+          ],
+          [
+            84.601359,
+            14.305759
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    84.644838,
+    12.882266,
+    94.444565,
+    21.317305
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-05-20T04:31:37Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 79.942,
+    "view:sun_elevation": 70.182,
+    "view:off_nadir": 0.0022774,
+    "proj:epsg": 32646,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 23,
+    "cbers:row": 81
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/023/081/CBERS_4_AWFI_20200520_023_081_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/023/081/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/023/081/CBERS_4_AWFI_20200520_023_081_L2/CBERS_4_AWFI_20200520_023_081.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/081/CBERS_4_AWFI_20200520_023_081_L2/CBERS_4_AWFI_20200520_023_081_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/081/CBERS_4_AWFI_20200520_023_081_L2/CBERS_4_AWFI_20200520_023_081_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/081/CBERS_4_AWFI_20200520_023_081_L2/CBERS_4_AWFI_20200520_023_081_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/081/CBERS_4_AWFI_20200520_023_081_L2/CBERS_4_AWFI_20200520_023_081_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/023/081/CBERS_4_AWFI_20200520_023_081_L2/CBERS_4_AWFI_20200520_023_081_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/081/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/081/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 023/081",
+  "description": "CBERS4 AWFI camera path 023 row 081 catalog",
+  "title": "CBERS4 AWFI 023/081",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/023/081/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20200520_023_081_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/023/catalog.json
@@ -1,0 +1,37 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 023",
+  "description": "CBERS4 AWFI camera path 023 catalog",
+  "title": "CBERS4 AWFI 023",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/023/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json"
+    },
+    {
+      "rel": "child",
+      "href": "063/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "069/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "075/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "081/catalog.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/027/057/CBERS_4_AWFI_20200725_027_057_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/027/057/CBERS_4_AWFI_20200725_027_057_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20200725_027_057_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            85.422034,
+            35.757975
+          ],
+          [
+            95.001705,
+            34.284393
+          ],
+          [
+            97.562288,
+            40.91609
+          ],
+          [
+            87.070961,
+            42.528986
+          ],
+          [
+            85.422034,
+            35.757975
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    85.569699,
+    34.036741,
+    97.711022,
+    42.663409
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-07-25T04:42:43Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 135.577,
+    "view:sun_elevation": 64.7993,
+    "view:off_nadir": 0.00440686,
+    "proj:epsg": 32646,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 27,
+    "cbers:row": 57
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/027/057/CBERS_4_AWFI_20200725_027_057_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/027/057/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/027/057/CBERS_4_AWFI_20200725_027_057_L2/CBERS_4_AWFI_20200725_027_057.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/027/057/CBERS_4_AWFI_20200725_027_057_L2/CBERS_4_AWFI_20200725_027_057_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/027/057/CBERS_4_AWFI_20200725_027_057_L2/CBERS_4_AWFI_20200725_027_057_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/027/057/CBERS_4_AWFI_20200725_027_057_L2/CBERS_4_AWFI_20200725_027_057_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/027/057/CBERS_4_AWFI_20200725_027_057_L2/CBERS_4_AWFI_20200725_027_057_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/027/057/CBERS_4_AWFI_20200725_027_057_L2/CBERS_4_AWFI_20200725_027_057_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/027/057/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/027/057/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 027/057",
+  "description": "CBERS4 AWFI camera path 027 row 057 catalog",
+  "title": "CBERS4 AWFI 027/057",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/027/057/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20200725_027_057_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/027/063/CBERS_4_AWFI_20200725_027_063_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/027/063/CBERS_4_AWFI_20200725_027_063_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20200725_027_063_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            84.205334,
+            30.40257
+          ],
+          [
+            93.245513,
+            29.01057
+          ],
+          [
+            95.504919,
+            35.683481
+          ],
+          [
+            85.75691,
+            37.182657
+          ],
+          [
+            84.205334,
+            30.40257
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    84.34404,
+    28.693678,
+    95.583831,
+    37.454387
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-07-25T04:44:13Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 123.965,
+    "view:sun_elevation": 67.4257,
+    "view:off_nadir": 0.00440686,
+    "proj:epsg": 32646,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 27,
+    "cbers:row": 63
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/027/063/CBERS_4_AWFI_20200725_027_063_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/027/063/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/027/063/CBERS_4_AWFI_20200725_027_063_L2/CBERS_4_AWFI_20200725_027_063.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/027/063/CBERS_4_AWFI_20200725_027_063_L2/CBERS_4_AWFI_20200725_027_063_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/027/063/CBERS_4_AWFI_20200725_027_063_L2/CBERS_4_AWFI_20200725_027_063_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/027/063/CBERS_4_AWFI_20200725_027_063_L2/CBERS_4_AWFI_20200725_027_063_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/027/063/CBERS_4_AWFI_20200725_027_063_L2/CBERS_4_AWFI_20200725_027_063_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/027/063/CBERS_4_AWFI_20200725_027_063_L2/CBERS_4_AWFI_20200725_027_063_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/027/063/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/027/063/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 027/063",
+  "description": "CBERS4 AWFI camera path 027 row 063 catalog",
+  "title": "CBERS4 AWFI 027/063",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/027/063/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20200725_027_063_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/027/069/CBERS_4_AWFI_20200725_027_069_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/027/069/CBERS_4_AWFI_20200725_027_069_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20200725_027_069_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            83.035015,
+            25.040843
+          ],
+          [
+            91.660918,
+            23.71101
+          ],
+          [
+            93.693937,
+            30.4162
+          ],
+          [
+            84.523534,
+            31.827833
+          ],
+          [
+            83.035015,
+            25.040843
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    83.069853,
+    23.692631,
+    93.803503,
+    31.747622
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-07-25T04:45:43Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 110.281,
+    "view:sun_elevation": 69.0063,
+    "view:off_nadir": 0.00440686,
+    "proj:epsg": 32645,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 27,
+    "cbers:row": 69
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/027/069/CBERS_4_AWFI_20200725_027_069_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/027/069/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/027/069/CBERS_4_AWFI_20200725_027_069_L2/CBERS_4_AWFI_20200725_027_069.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/027/069/CBERS_4_AWFI_20200725_027_069_L2/CBERS_4_AWFI_20200725_027_069_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/027/069/CBERS_4_AWFI_20200725_027_069_L2/CBERS_4_AWFI_20200725_027_069_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/027/069/CBERS_4_AWFI_20200725_027_069_L2/CBERS_4_AWFI_20200725_027_069_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/027/069/CBERS_4_AWFI_20200725_027_069_L2/CBERS_4_AWFI_20200725_027_069_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/027/069/CBERS_4_AWFI_20200725_027_069_L2/CBERS_4_AWFI_20200725_027_069_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/027/069/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/027/069/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 027/069",
+  "description": "CBERS4 AWFI camera path 027 row 069 catalog",
+  "title": "CBERS4 AWFI 027/069",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/027/069/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20200725_027_069_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/027/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/027/catalog.json
@@ -1,0 +1,33 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 027",
+  "description": "CBERS4 AWFI camera path 027 catalog",
+  "title": "CBERS4 AWFI 027",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/027/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json"
+    },
+    {
+      "rel": "child",
+      "href": "057/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "063/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "069/catalog.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/028/027/CBERS_4_AWFI_20190628_028_027_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/028/027/CBERS_4_AWFI_20190628_028_027_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20190628_028_027_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            92.84086,
+            62.383272
+          ],
+          [
+            108.686107,
+            59.897889
+          ],
+          [
+            116.169801,
+            65.911643
+          ],
+          [
+            96.743989,
+            69.034571
+          ],
+          [
+            92.84086,
+            62.383272
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    93.897436,
+    59.440506,
+    117.726922,
+    68.831478
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2019-06-28T04:25:04Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 169.313,
+    "view:sun_elevation": 47.2842,
+    "view:off_nadir": 0.00681096,
+    "proj:epsg": 32648,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 28,
+    "cbers:row": 27
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/028/027/CBERS_4_AWFI_20190628_028_027_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/028/027/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/028/027/CBERS_4_AWFI_20190628_028_027_L2/CBERS_4_AWFI_20190628_028_027.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/028/027/CBERS_4_AWFI_20190628_028_027_L2/CBERS_4_AWFI_20190628_028_027_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/028/027/CBERS_4_AWFI_20190628_028_027_L2/CBERS_4_AWFI_20190628_028_027_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/028/027/CBERS_4_AWFI_20190628_028_027_L2/CBERS_4_AWFI_20190628_028_027_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/028/027/CBERS_4_AWFI_20190628_028_027_L2/CBERS_4_AWFI_20190628_028_027_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/028/027/CBERS_4_AWFI_20190628_028_027_L2/CBERS_4_AWFI_20190628_028_027_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/028/027/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/028/027/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 028/027",
+  "description": "CBERS4 AWFI camera path 028 row 027 catalog",
+  "title": "CBERS4 AWFI 028/027",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/028/027/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20190628_028_027_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/028/033/CBERS_4_AWFI_20190628_028_033_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/028/033/CBERS_4_AWFI_20190628_028_033_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20190628_028_033_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            90.60674,
+            57.090101
+          ],
+          [
+            104.437553,
+            54.939639
+          ],
+          [
+            110.024073,
+            61.190014
+          ],
+          [
+            93.535395,
+            63.78547
+          ],
+          [
+            90.60674,
+            57.090101
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    91.07885,
+    54.76451,
+    110.95405,
+    63.465669
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2019-06-28T04:26:34Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 161.706,
+    "view:sun_elevation": 51.9007,
+    "view:off_nadir": 0.00681096,
+    "proj:epsg": 32647,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 28,
+    "cbers:row": 33
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/028/033/CBERS_4_AWFI_20190628_028_033_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/028/033/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/028/033/CBERS_4_AWFI_20190628_028_033_L2/CBERS_4_AWFI_20190628_028_033.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/028/033/CBERS_4_AWFI_20190628_028_033_L2/CBERS_4_AWFI_20190628_028_033_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/028/033/CBERS_4_AWFI_20190628_028_033_L2/CBERS_4_AWFI_20190628_028_033_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/028/033/CBERS_4_AWFI_20190628_028_033_L2/CBERS_4_AWFI_20190628_028_033_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/028/033/CBERS_4_AWFI_20190628_028_033_L2/CBERS_4_AWFI_20190628_028_033_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/028/033/CBERS_4_AWFI_20190628_028_033_L2/CBERS_4_AWFI_20190628_028_033_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/028/033/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/028/033/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 028/033",
+  "description": "CBERS4 AWFI camera path 028 row 033 catalog",
+  "title": "CBERS4 AWFI 028/033",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/028/033/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20190628_028_033_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/028/045/CBERS_4_AWFI_20190628_028_045_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/028/045/CBERS_4_AWFI_20190628_028_045_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20190628_028_045_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            87.208918,
+            46.448807
+          ],
+          [
+            98.368098,
+            44.724275
+          ],
+          [
+            101.916373,
+            51.227967
+          ],
+          [
+            89.237178,
+            53.192576
+          ],
+          [
+            87.208918,
+            46.448807
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    87.376965,
+    44.673764,
+    102.300989,
+    52.964746
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2019-06-28T04:29:35Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 146.095,
+    "view:sun_elevation": 60.1043,
+    "view:off_nadir": 0.00681096,
+    "proj:epsg": 32646,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 28,
+    "cbers:row": 45
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/028/045/CBERS_4_AWFI_20190628_028_045_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/028/045/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/028/045/CBERS_4_AWFI_20190628_028_045_L2/CBERS_4_AWFI_20190628_028_045.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/028/045/CBERS_4_AWFI_20190628_028_045_L2/CBERS_4_AWFI_20190628_028_045_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/028/045/CBERS_4_AWFI_20190628_028_045_L2/CBERS_4_AWFI_20190628_028_045_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/028/045/CBERS_4_AWFI_20190628_028_045_L2/CBERS_4_AWFI_20190628_028_045_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/028/045/CBERS_4_AWFI_20190628_028_045_L2/CBERS_4_AWFI_20190628_028_045_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/028/045/CBERS_4_AWFI_20190628_028_045_L2/CBERS_4_AWFI_20190628_028_045_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/028/045/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/028/045/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 028/045",
+  "description": "CBERS4 AWFI camera path 028 row 045 catalog",
+  "title": "CBERS4 AWFI 028/045",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/028/045/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20190628_028_045_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/028/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/028/catalog.json
@@ -1,0 +1,33 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 028",
+  "description": "CBERS4 AWFI camera path 028 catalog",
+  "title": "CBERS4 AWFI 028",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/028/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json"
+    },
+    {
+      "rel": "child",
+      "href": "027/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "033/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "045/catalog.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/051/CBERS_4_AWFI_20191007_029_051_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/051/CBERS_4_AWFI_20191007_029_051_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20191007_029_051_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            84.863084,
+            41.108523
+          ],
+          [
+            95.126085,
+            39.524873
+          ],
+          [
+            98.102691,
+            46.102357
+          ],
+          [
+            86.666748,
+            47.868162
+          ],
+          [
+            84.863084,
+            41.108523
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    85.073255,
+    39.235148,
+    98.314721,
+    47.997145
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2019-10-07T04:39:16Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 161.274,
+    "view:sun_elevation": 38.5044,
+    "view:off_nadir": 0.00590737,
+    "proj:epsg": 32646,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 29,
+    "cbers:row": 51
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/051/CBERS_4_AWFI_20191007_029_051_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/051/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/029/051/CBERS_4_AWFI_20191007_029_051_L2/CBERS_4_AWFI_20191007_029_051.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/051/CBERS_4_AWFI_20191007_029_051_L2/CBERS_4_AWFI_20191007_029_051_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/051/CBERS_4_AWFI_20191007_029_051_L2/CBERS_4_AWFI_20191007_029_051_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/051/CBERS_4_AWFI_20191007_029_051_L2/CBERS_4_AWFI_20191007_029_051_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/051/CBERS_4_AWFI_20191007_029_051_L2/CBERS_4_AWFI_20191007_029_051_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/051/CBERS_4_AWFI_20191007_029_051_L2/CBERS_4_AWFI_20191007_029_051_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/051/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/051/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 029/051",
+  "description": "CBERS4 AWFI camera path 029 row 051 catalog",
+  "title": "CBERS4 AWFI 029/051",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/051/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20191007_029_051_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/057/CBERS_4_AWFI_20191007_029_057_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/057/CBERS_4_AWFI_20191007_029_057_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20191007_029_057_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            83.568239,
+            35.759838
+          ],
+          [
+            93.136825,
+            34.282614
+          ],
+          [
+            95.703809,
+            40.914227
+          ],
+          [
+            85.224514,
+            42.531244
+          ],
+          [
+            83.568239,
+            35.759838
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    83.769414,
+    33.896195,
+    95.81143,
+    42.838832
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2019-10-07T04:40:46Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 157.693,
+    "view:sun_elevation": 43.1067,
+    "view:off_nadir": 0.00590737,
+    "proj:epsg": 32646,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 29,
+    "cbers:row": 57
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/057/CBERS_4_AWFI_20191007_029_057_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/057/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/029/057/CBERS_4_AWFI_20191007_029_057_L2/CBERS_4_AWFI_20191007_029_057.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/057/CBERS_4_AWFI_20191007_029_057_L2/CBERS_4_AWFI_20191007_029_057_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/057/CBERS_4_AWFI_20191007_029_057_L2/CBERS_4_AWFI_20191007_029_057_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/057/CBERS_4_AWFI_20191007_029_057_L2/CBERS_4_AWFI_20191007_029_057_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/057/CBERS_4_AWFI_20191007_029_057_L2/CBERS_4_AWFI_20191007_029_057_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/057/CBERS_4_AWFI_20191007_029_057_L2/CBERS_4_AWFI_20191007_029_057_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/057/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/057/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 029/057",
+  "description": "CBERS4 AWFI camera path 029 row 057 catalog",
+  "title": "CBERS4 AWFI 029/057",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/057/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20191007_029_057_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/063/CBERS_4_AWFI_20191007_029_063_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/063/CBERS_4_AWFI_20191007_029_063_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20191007_029_063_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            82.346447,
+            30.40355
+          ],
+          [
+            91.376107,
+            29.008187
+          ],
+          [
+            93.641287,
+            35.681679
+          ],
+          [
+            83.904539,
+            37.184583
+          ],
+          [
+            82.346447,
+            30.40355
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    82.404707,
+    28.961938,
+    93.781807,
+    37.108078
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2019-10-07T04:42:16Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 153.704,
+    "view:sun_elevation": 47.5513,
+    "view:off_nadir": 0.00590737,
+    "proj:epsg": 32645,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 29,
+    "cbers:row": 63
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/063/CBERS_4_AWFI_20191007_029_063_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/063/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/029/063/CBERS_4_AWFI_20191007_029_063_L2/CBERS_4_AWFI_20191007_029_063.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/063/CBERS_4_AWFI_20191007_029_063_L2/CBERS_4_AWFI_20191007_029_063_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/063/CBERS_4_AWFI_20191007_029_063_L2/CBERS_4_AWFI_20191007_029_063_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/063/CBERS_4_AWFI_20191007_029_063_L2/CBERS_4_AWFI_20191007_029_063_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/063/CBERS_4_AWFI_20191007_029_063_L2/CBERS_4_AWFI_20191007_029_063_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/063/CBERS_4_AWFI_20191007_029_063_L2/CBERS_4_AWFI_20191007_029_063_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/063/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/063/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 029/063",
+  "description": "CBERS4 AWFI camera path 029 row 063 catalog",
+  "title": "CBERS4 AWFI 029/063",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/063/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20191007_029_063_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/069/CBERS_4_AWFI_20191007_029_069_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/069/CBERS_4_AWFI_20191007_029_069_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20191007_029_069_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            81.171785,
+            25.04201
+          ],
+          [
+            89.787754,
+            23.709003
+          ],
+          [
+            91.826035,
+            30.415067
+          ],
+          [
+            82.666189,
+            31.830148
+          ],
+          [
+            81.171785,
+            25.04201
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    81.230253,
+    23.588255,
+    91.91789,
+    31.886603
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2019-10-07T04:43:47Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 149.069,
+    "view:sun_elevation": 51.7885,
+    "view:off_nadir": 0.00590737,
+    "proj:epsg": 32645,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 29,
+    "cbers:row": 69
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/069/CBERS_4_AWFI_20191007_029_069_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/069/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/029/069/CBERS_4_AWFI_20191007_029_069_L2/CBERS_4_AWFI_20191007_029_069.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/069/CBERS_4_AWFI_20191007_029_069_L2/CBERS_4_AWFI_20191007_029_069_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/069/CBERS_4_AWFI_20191007_029_069_L2/CBERS_4_AWFI_20191007_029_069_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/069/CBERS_4_AWFI_20191007_029_069_L2/CBERS_4_AWFI_20191007_029_069_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/069/CBERS_4_AWFI_20191007_029_069_L2/CBERS_4_AWFI_20191007_029_069_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/069/CBERS_4_AWFI_20191007_029_069_L2/CBERS_4_AWFI_20191007_029_069_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/069/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/069/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 029/069",
+  "description": "CBERS4 AWFI camera path 029 row 069 catalog",
+  "title": "CBERS4 AWFI 029/069",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/069/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20191007_029_069_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/075/CBERS_4_AWFI_20201126_029_075_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/075/CBERS_4_AWFI_20201126_029_075_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20201126_029_075_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            80.019061,
+            19.674293
+          ],
+          [
+            88.335149,
+            18.391713
+          ],
+          [
+            90.194038,
+            25.122265
+          ],
+          [
+            81.468486,
+            26.465816
+          ],
+          [
+            80.019061,
+            19.674293
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    80.072025,
+    18.231792,
+    90.250022,
+    26.614376
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-11-26T04:57:31Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 158.818,
+    "view:sun_elevation": 43.1372,
+    "view:off_nadir": 0.00290518,
+    "proj:epsg": 32645,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 29,
+    "cbers:row": 75
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/075/CBERS_4_AWFI_20201126_029_075_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/075/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/029/075/CBERS_4_AWFI_20201126_029_075_L2/CBERS_4_AWFI_20201126_029_075.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/075/CBERS_4_AWFI_20201126_029_075_L2/CBERS_4_AWFI_20201126_029_075_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/075/CBERS_4_AWFI_20201126_029_075_L2/CBERS_4_AWFI_20201126_029_075_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/075/CBERS_4_AWFI_20201126_029_075_L2/CBERS_4_AWFI_20201126_029_075_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/075/CBERS_4_AWFI_20201126_029_075_L2/CBERS_4_AWFI_20201126_029_075_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/075/CBERS_4_AWFI_20201126_029_075_L2/CBERS_4_AWFI_20201126_029_075_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/075/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/075/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 029/075",
+  "description": "CBERS4 AWFI camera path 029 row 075 catalog",
+  "title": "CBERS4 AWFI 029/075",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/075/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20201126_029_075_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/081/CBERS_4_AWFI_20201126_029_081_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/081/CBERS_4_AWFI_20201126_029_081_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20201126_029_081_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            78.887957,
+            14.306141
+          ],
+          [
+            86.98348,
+            13.05606
+          ],
+          [
+            88.710063,
+            19.80673
+          ],
+          [
+            80.320807,
+            21.100159
+          ],
+          [
+            78.887957,
+            14.306141
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    78.929162,
+    12.891819,
+    88.741742,
+    21.301194
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-11-26T04:59:01Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 155.55,
+    "view:sun_elevation": 47.745,
+    "view:off_nadir": 0.00290518,
+    "proj:epsg": 32645,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 29,
+    "cbers:row": 81
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/081/CBERS_4_AWFI_20201126_029_081_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/081/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/029/081/CBERS_4_AWFI_20201126_029_081_L2/CBERS_4_AWFI_20201126_029_081.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/081/CBERS_4_AWFI_20201126_029_081_L2/CBERS_4_AWFI_20201126_029_081_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/081/CBERS_4_AWFI_20201126_029_081_L2/CBERS_4_AWFI_20201126_029_081_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/081/CBERS_4_AWFI_20201126_029_081_L2/CBERS_4_AWFI_20201126_029_081_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/081/CBERS_4_AWFI_20201126_029_081_L2/CBERS_4_AWFI_20201126_029_081_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/081/CBERS_4_AWFI_20201126_029_081_L2/CBERS_4_AWFI_20201126_029_081_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/081/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/081/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 029/081",
+  "description": "CBERS4 AWFI camera path 029 row 081 catalog",
+  "title": "CBERS4 AWFI 029/081",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/081/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20201126_029_081_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/087/CBERS_4_AWFI_20201126_029_087_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/087/CBERS_4_AWFI_20201126_029_087_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20201126_029_087_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            77.754124,
+            8.937773
+          ],
+          [
+            85.708954,
+            7.708122
+          ],
+          [
+            87.333913,
+            14.473835
+          ],
+          [
+            79.187956,
+            15.731319
+          ],
+          [
+            77.754124,
+            8.937773
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    77.758804,
+    7.682578,
+    87.383469,
+    15.723028
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2020-11-26T05:00:32Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 151.574,
+    "view:sun_elevation": 52.1795,
+    "view:off_nadir": 0.00290518,
+    "proj:epsg": 32644,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 29,
+    "cbers:row": 87
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/087/CBERS_4_AWFI_20201126_029_087_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/087/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/029/087/CBERS_4_AWFI_20201126_029_087_L2/CBERS_4_AWFI_20201126_029_087.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/087/CBERS_4_AWFI_20201126_029_087_L2/CBERS_4_AWFI_20201126_029_087_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/087/CBERS_4_AWFI_20201126_029_087_L2/CBERS_4_AWFI_20201126_029_087_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/087/CBERS_4_AWFI_20201126_029_087_L2/CBERS_4_AWFI_20201126_029_087_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/087/CBERS_4_AWFI_20201126_029_087_L2/CBERS_4_AWFI_20201126_029_087_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/029/087/CBERS_4_AWFI_20201126_029_087_L2/CBERS_4_AWFI_20201126_029_087_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/087/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/087/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 029/087",
+  "description": "CBERS4 AWFI camera path 029 row 087 catalog",
+  "title": "CBERS4 AWFI 029/087",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/087/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20201126_029_087_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/029/catalog.json
@@ -1,0 +1,49 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 029",
+  "description": "CBERS4 AWFI camera path 029 catalog",
+  "title": "CBERS4 AWFI 029",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/029/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json"
+    },
+    {
+      "rel": "child",
+      "href": "051/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "057/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "063/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "069/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "075/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "081/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "087/catalog.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/030/051/CBERS_4_AWFI_20191004_030_051_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/030/051/CBERS_4_AWFI_20191004_030_051_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20191004_030_051_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            83.8995,
+            41.108835
+          ],
+          [
+            94.162543,
+            39.525017
+          ],
+          [
+            97.139131,
+            46.102476
+          ],
+          [
+            85.703024,
+            47.868447
+          ],
+          [
+            83.8995,
+            41.108835
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    84.146586,
+    39.154703,
+    97.325763,
+    48.096337
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2019-10-04T04:43:00Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 160.61,
+    "view:sun_elevation": 39.567,
+    "view:off_nadir": 0.00606138,
+    "proj:epsg": 32646,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 30,
+    "cbers:row": 51
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/030/051/CBERS_4_AWFI_20191004_030_051_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/030/051/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/030/051/CBERS_4_AWFI_20191004_030_051_L2/CBERS_4_AWFI_20191004_030_051.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/030/051/CBERS_4_AWFI_20191004_030_051_L2/CBERS_4_AWFI_20191004_030_051_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/030/051/CBERS_4_AWFI_20191004_030_051_L2/CBERS_4_AWFI_20191004_030_051_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/030/051/CBERS_4_AWFI_20191004_030_051_L2/CBERS_4_AWFI_20191004_030_051_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/030/051/CBERS_4_AWFI_20191004_030_051_L2/CBERS_4_AWFI_20191004_030_051_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/030/051/CBERS_4_AWFI_20191004_030_051_L2/CBERS_4_AWFI_20191004_030_051_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/030/051/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/030/051/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 030/051",
+  "description": "CBERS4 AWFI camera path 030 row 051 catalog",
+  "title": "CBERS4 AWFI 030/051",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/030/051/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20191004_030_051_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/030/057/CBERS_4_AWFI_20191004_030_057_L2.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/030/057/CBERS_4_AWFI_20191004_030_057_L2.json
@@ -1,0 +1,129 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+  ],
+  "id": "CBERS_4_AWFI_20191004_030_057_L2",
+  "type": "Feature",
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      [
+        [
+          [
+            82.604567,
+            35.759379
+          ],
+          [
+            92.17302,
+            34.282013
+          ],
+          [
+            94.739994,
+            40.913727
+          ],
+          [
+            84.260735,
+            42.530892
+          ],
+          [
+            82.604567,
+            35.759379
+          ]
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    82.674698,
+    34.276407,
+    94.935824,
+    42.366041
+  ],
+  "collection": "CBERS4-AWFI",
+  "properties": {
+    "datetime": "2019-10-04T04:44:30Z",
+    "platform": "cbers-4",
+    "instruments": [
+      "AWFI"
+    ],
+    "gsd": 64.0,
+    "view:sun_azimuth": 156.88,
+    "view:sun_elevation": 44.1317,
+    "view:off_nadir": 0.00606138,
+    "proj:epsg": 32645,
+    "sat:platform_international_designator": "2014-079A",
+    "sat:orbit_state": "descending",
+    "cbers:data_type": "L2",
+    "cbers:path": 30,
+    "cbers:row": 57
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/030/057/CBERS_4_AWFI_20191004_030_057_L2.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/030/057/catalog.json"
+    },
+    {
+      "rel": "collection",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/collection.json"
+    }
+  ],
+  "assets": {
+    "thumbnail": {
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/030/057/CBERS_4_AWFI_20191004_030_057_L2/CBERS_4_AWFI_20191004_030_057.jpg",
+      "type": "image/jpeg"
+    },
+    "metadata": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/030/057/CBERS_4_AWFI_20191004_030_057_L2/CBERS_4_AWFI_20191004_030_057_L2_BAND14.xml",
+      "title": "INPE original metadata",
+      "type": "text/xml"
+    },
+    "B13": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/030/057/CBERS_4_AWFI_20191004_030_057_L2/CBERS_4_AWFI_20191004_030_057_L2_BAND13.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B13",
+          "common_name": "blue"
+        }
+      ]
+    },
+    "B14": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/030/057/CBERS_4_AWFI_20191004_030_057_L2/CBERS_4_AWFI_20191004_030_057_L2_BAND14.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B14",
+          "common_name": "green"
+        }
+      ]
+    },
+    "B15": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/030/057/CBERS_4_AWFI_20191004_030_057_L2/CBERS_4_AWFI_20191004_030_057_L2_BAND15.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B15",
+          "common_name": "red"
+        }
+      ]
+    },
+    "B16": {
+      "href": "s3://cbers-pds/CBERS4/AWFI/030/057/CBERS_4_AWFI_20191004_030_057_L2/CBERS_4_AWFI_20191004_030_057_L2_BAND16.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "eo:bands": [
+        {
+          "name": "B16",
+          "common_name": "nir"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/030/057/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/030/057/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 030/057",
+  "description": "CBERS4 AWFI camera path 030 row 057 catalog",
+  "title": "CBERS4 AWFI 030/057",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/030/057/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20191004_030_057_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/030/069/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/030/069/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 030/069",
+  "description": "CBERS4 AWFI camera path 030 row 069 catalog",
+  "title": "CBERS4 AWFI 030/069",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/030/069/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json"
+    },
+    {
+      "rel": "item",
+      "href": "CBERS_4_AWFI_20191004_030_069_L2.json"
+    }
+  ]
+}

--- a/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/030/catalog.json
+++ b/test/fixtures/cbers_stac_bucket_structure/CBERS4/AWFI/030/catalog.json
@@ -1,0 +1,37 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "id": "CBERS4 AWFI 030",
+  "description": "CBERS4 AWFI camera path 030 catalog",
+  "title": "CBERS4 AWFI 030",
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/CBERS4/AWFI/030/catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://cbers-stac-1-0-0.s3.amazonaws.com/catalog.json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json"
+    },
+    {
+      "rel": "child",
+      "href": "051/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "057/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "063/catalog.json"
+    },
+    {
+      "rel": "child",
+      "href": "069/catalog.json"
+    }
+  ]
+}

--- a/test/reindex_stac_items_test.py
+++ b/test/reindex_stac_items_test.py
@@ -1,0 +1,36 @@
+"""reindex_stac_items_test."""
+
+import pathlib
+from test.utils import check_queue_size
+
+import pytest
+
+from cbers2stac.reindex_stac_items.code import send_stac_items_to_queue
+
+
+@pytest.mark.s3_bucket_args("cbers-stac")
+@pytest.mark.sqs_queue_args("queue")
+def test_send_stac_items_to_queue(s3_bucket, sqs_queue):
+    """test_send_stac_items_to_queue."""
+
+    s3_client, s3_resource = s3_bucket  # pylint: disable=unused-variable
+    queue = sqs_queue
+
+    fixture_prefix = "test/fixtures/cbers_stac_bucket_structure/"
+    paths = pathlib.Path(fixture_prefix).rglob("*")
+    jsons = [str(f.relative_to(fixture_prefix)) for f in paths if "json" in str(f)]
+    for jfile in jsons:
+        s3_client.upload_file(
+            Filename=fixture_prefix + "/" + jfile, Bucket="cbers-stac", Key=jfile
+        )
+
+    send_stac_items_to_queue(
+        bucket="cbers-stac", queue=queue.url, prefix="CBERS4/AWFI/001/",
+    )
+    check_queue_size(sqs_queue, 4)
+
+    send_stac_items_to_queue(
+        bucket="cbers-stac", queue=queue.url, prefix="CBERS4/AWFI/"
+    )
+    # We must consider the 4 messages added in the previous test
+    check_queue_size(sqs_queue, 52 + 4)


### PR DESCRIPTION
* No new items are added if the index becomes corrupted
* Last 3 days of ingested STAC items are stored in a backup queue, this allows them to be re-indexed after recovering the ES cluster from a backup
* Support for reconciliation (re-indexing) from static STAC items - previously the STAC items had to be regenerated from INPE's XML metadata.
* Some ES cluster are now parameters.